### PR TITLE
Feature/2 remaining endpoints

### DIFF
--- a/src/FinancialData.Tests/Entities/BalanceSheetTests.cs
+++ b/src/FinancialData.Tests/Entities/BalanceSheetTests.cs
@@ -56,7 +56,7 @@ namespace FinancialData.Tests.Entities
             Assert.AreEqual(57228000000.0m, balanceSheet.MarketableSecuritiesCurrent);
             Assert.AreEqual(56924000000.0m, balanceSheet.AccountsReceivable);
             Assert.AreEqual(1246000000.0m, balanceSheet.Inventories);
-            Assert.IsNull(balanceSheet.NonTradeReceivables);
+            Assert.AreEqual(0m, balanceSheet.NonTradeReceivables); // Null converts to 0 with DecimalNullToZeroConverter
             Assert.AreEqual(26021000000.0m, balanceSheet.OtherAssetsCurrent);
             Assert.AreEqual(159734000000.0m, balanceSheet.TotalAssetsCurrent);
             Assert.AreEqual(14600000000.0m, balanceSheet.MarketableSecuritiesNonCurrent);

--- a/src/FinancialData.Tests/Entities/CompanyInformationTests.cs
+++ b/src/FinancialData.Tests/Entities/CompanyInformationTests.cs
@@ -36,6 +36,17 @@ namespace FinancialData.Tests.Entities
             Assert.AreEqual("AAPL", companyInfo.TradingSymbol);
             Assert.AreEqual("0000320193", companyInfo.CentralIndexKey);
             Assert.AreEqual("Apple Inc.", companyInfo.RegistrantName);
+            Assert.AreEqual("US0378331005", companyInfo.IsinNumber);
+            Assert.AreEqual("HWUPKR0MPOU8FGXBT394", companyInfo.LeiNumber);
+            Assert.AreEqual("942404110", companyInfo.EinNumber);
+            Assert.AreEqual("NASDAQ", companyInfo.Exchange);
+            Assert.AreEqual("3571", companyInfo.SicCode);
+            Assert.AreEqual("Electronic Computers", companyInfo.SicDescription);
+            Assert.AreEqual("0930", companyInfo.FiscalYearEnd);
+            Assert.AreEqual("CA", companyInfo.StateOfIncorporation);
+            Assert.AreEqual("(408) 996-1010", companyInfo.PhoneNumber);
+            Assert.AreEqual("Technology", companyInfo.Industry);
+            Assert.AreEqual("https://www.apple.com", companyInfo.Website);
             Assert.AreEqual(2800000000000m, companyInfo.MarketCap);
             Assert.AreEqual(0m, companyInfo.SharesIssued);
             Assert.AreEqual(15550000000m, companyInfo.SharesOutstanding);

--- a/src/FinancialData.Tests/Entities/CompanyInformationTests.cs
+++ b/src/FinancialData.Tests/Entities/CompanyInformationTests.cs
@@ -1,0 +1,45 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+using Tudormobile.FinancialData.Entities;
+using Tudormobile.FinancialData;
+
+namespace FinancialData.Tests.Entities
+{
+    [TestClass]
+    public class CompanyInformationTests
+    {
+        [TestMethod]
+        public void CompanyInformation_Deserialize_FromJson_Works()
+        {
+            var json = @"{
+    ""trading_symbol"": ""AAPL"",
+    ""central_index_key"": ""0000320193"",
+    ""registrant_name"": ""Apple Inc."",
+    ""isin_number"": ""US0378331005"",
+    ""lei_number"": ""HWUPKR0MPOU8FGXBT394"",
+    ""ein_number"": ""942404110"",
+    ""exchange"": ""NASDAQ"",
+    ""sic_code"": ""3571"",
+    ""sic_description"": ""Electronic Computers"",
+    ""fiscal_year_end"": ""0930"",
+    ""state_of_incorporation"": ""CA"",
+    ""phone_number"": ""(408) 996-1010"",
+    ""industry"": ""Technology"",
+    ""website"": ""https://www.apple.com"",
+    ""market_cap"": 2800000000000.0,
+    ""shares_issued"": null,
+    ""shares_outstanding"": 15550000000.0,
+    ""number_of_employees"": 161000
+}";
+            using var doc = JsonDocument.Parse(json);
+            var companyInfo = FinancialDataSerializer.Instance.Deserialize<CompanyInformation>(doc);
+            Assert.AreEqual("AAPL", companyInfo.TradingSymbol);
+            Assert.AreEqual("0000320193", companyInfo.CentralIndexKey);
+            Assert.AreEqual("Apple Inc.", companyInfo.RegistrantName);
+            Assert.AreEqual(2800000000000m, companyInfo.MarketCap);
+            Assert.AreEqual(0m, companyInfo.SharesIssued);
+            Assert.AreEqual(15550000000m, companyInfo.SharesOutstanding);
+            Assert.AreEqual(161000, companyInfo.NumberOfEmployees);
+        }
+    }
+}

--- a/src/FinancialData.Tests/Entities/CryptoInformationTests.cs
+++ b/src/FinancialData.Tests/Entities/CryptoInformationTests.cs
@@ -1,0 +1,30 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+using Tudormobile.FinancialData.Entities;
+using Tudormobile.FinancialData;
+
+namespace FinancialData.Tests.Entities
+{
+    [TestClass]
+    public class CryptoInformationTests
+    {
+        [TestMethod]
+        public void CryptoInformation_Deserialize_FromJson_Works()
+        {
+            var json = @"{
+    ""trading_symbol"": ""BTC-USD"",
+    ""name"": ""Bitcoin"",
+    ""website"": ""https://bitcoin.org"",
+    ""description"": ""Bitcoin is a decentralized digital currency."",
+    ""founding_date"": ""2009-01-03"",
+    ""founder"": ""Satoshi Nakamoto""
+}";
+            using var doc = JsonDocument.Parse(json);
+            var cryptoInfo = FinancialDataSerializer.Instance.Deserialize<CryptoInformation>(doc);
+            Assert.AreEqual("BTC-USD", cryptoInfo.TradingSymbol);
+            Assert.AreEqual("Bitcoin", cryptoInfo.Name);
+            Assert.AreEqual("https://bitcoin.org", cryptoInfo.Website);
+            Assert.AreEqual("Satoshi Nakamoto", cryptoInfo.Founder);
+        }
+    }
+}

--- a/src/FinancialData.Tests/Entities/CryptoInformationTests.cs
+++ b/src/FinancialData.Tests/Entities/CryptoInformationTests.cs
@@ -24,6 +24,8 @@ namespace FinancialData.Tests.Entities
             Assert.AreEqual("BTC-USD", cryptoInfo.TradingSymbol);
             Assert.AreEqual("Bitcoin", cryptoInfo.Name);
             Assert.AreEqual("https://bitcoin.org", cryptoInfo.Website);
+            Assert.AreEqual("Bitcoin is a decentralized digital currency.", cryptoInfo.Description);
+            Assert.AreEqual("2009-01-03", cryptoInfo.FoundingDate);
             Assert.AreEqual("Satoshi Nakamoto", cryptoInfo.Founder);
         }
     }

--- a/src/FinancialData.Tests/Entities/CryptoMinutePriceTests.cs
+++ b/src/FinancialData.Tests/Entities/CryptoMinutePriceTests.cs
@@ -1,0 +1,31 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+using Tudormobile.FinancialData.Entities;
+using Tudormobile.FinancialData;
+
+namespace FinancialData.Tests.Entities
+{
+    [TestClass]
+    public class CryptoMinutePriceTests
+    {
+        [TestMethod]
+        public void CryptoMinutePrice_Deserialize_FromJson_Works()
+        {
+            var json = @"{
+    ""trading_symbol"": ""BTC-USD"",
+    ""time"": ""2024-01-15 14:30:00"",
+    ""open"": 42500.50,
+    ""high"": 42550.75,
+    ""low"": 42480.25,
+    ""close"": 42540.00,
+    ""volume"": 125000000.0
+}";
+            using var doc = JsonDocument.Parse(json);
+            var cryptoMinutePrice = FinancialDataSerializer.Instance.Deserialize<CryptoMinutePrice>(doc);
+            Assert.AreEqual("BTC-USD", cryptoMinutePrice.TradingSymbol);
+            Assert.AreEqual(42500.50m, cryptoMinutePrice.Open);
+            Assert.AreEqual(42550.75m, cryptoMinutePrice.High);
+            Assert.AreEqual(42540.00m, cryptoMinutePrice.Close);
+        }
+    }
+}

--- a/src/FinancialData.Tests/Entities/CryptoPriceTests.cs
+++ b/src/FinancialData.Tests/Entities/CryptoPriceTests.cs
@@ -1,0 +1,32 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+using Tudormobile.FinancialData.Entities;
+using Tudormobile.FinancialData;
+
+namespace FinancialData.Tests.Entities
+{
+    [TestClass]
+    public class CryptoPriceTests
+    {
+        [TestMethod]
+        public void CryptoPrice_Deserialize_FromJson_Works()
+        {
+            var json = @"{
+    ""trading_symbol"": ""ETH-USD"",
+    ""date"": ""2024-01-15"",
+    ""open"": 2450.50,
+    ""high"": 2485.75,
+    ""low"": 2440.25,
+    ""close"": 2475.00,
+    ""volume"": 8500000000.0,
+    ""market_cap"": 295000000000.0
+}";
+            using var doc = JsonDocument.Parse(json);
+            var cryptoPrice = FinancialDataSerializer.Instance.Deserialize<CryptoPrice>(doc);
+            Assert.AreEqual("ETH-USD", cryptoPrice.TradingSymbol);
+            Assert.AreEqual(2450.50m, cryptoPrice.Open);
+            Assert.AreEqual(2485.75m, cryptoPrice.High);
+            Assert.AreEqual(2475.00m, cryptoPrice.Close);
+        }
+    }
+}

--- a/src/FinancialData.Tests/Entities/CryptoQuoteTests.cs
+++ b/src/FinancialData.Tests/Entities/CryptoQuoteTests.cs
@@ -1,0 +1,50 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+using Tudormobile.FinancialData.Entities;
+using Tudormobile.FinancialData;
+
+namespace FinancialData.Tests.Entities
+{
+    [TestClass]
+    public class CryptoQuoteTests
+    {
+        [TestMethod]
+        public void CryptoQuote_Deserialize_FromJson_Works()
+        {
+            var json = @"{
+    ""trading_symbol"": ""BTC-USD"",
+    ""time"": ""2024-01-15 14:30:00"",
+    ""price"": 42500.75,
+    ""volume"": 15000000000.0,
+    ""market_cap"": 830000000000.0,
+    ""percent_change"": 2.5
+}";
+            using var doc = JsonDocument.Parse(json);
+            var cryptoQuote = FinancialDataSerializer.Instance.Deserialize<CryptoQuote>(doc);
+            Assert.AreEqual("BTC-USD", cryptoQuote.TradingSymbol);
+            Assert.AreEqual(42500.75m, cryptoQuote.Price);
+            Assert.AreEqual(15000000000m, cryptoQuote.Volume);
+            Assert.AreEqual(830000000000m, cryptoQuote.MarketCap);
+            Assert.AreEqual(2.5m, cryptoQuote.PercentChange);
+        }
+
+        [TestMethod]
+        public void CryptoQuote_Deserialize_HandlesNullDecimals()
+        {
+            var json = @"{
+    ""trading_symbol"": ""BTC-USD"",
+    ""time"": ""2024-01-15 14:30:00"",
+    ""price"": 42500.75,
+    ""volume"": null,
+    ""market_cap"": null,
+    ""percent_change"": null
+}";
+            using var doc = JsonDocument.Parse(json);
+            var cryptoQuote = FinancialDataSerializer.Instance.Deserialize<CryptoQuote>(doc);
+            Assert.AreEqual(42500.75m, cryptoQuote.Price);
+            Assert.AreEqual(0m, cryptoQuote.Volume);
+            Assert.AreEqual(0m, cryptoQuote.MarketCap);
+            Assert.AreEqual(0m, cryptoQuote.PercentChange);
+        }
+    }
+}

--- a/src/FinancialData.Tests/Entities/CryptoSymbolTests.cs
+++ b/src/FinancialData.Tests/Entities/CryptoSymbolTests.cs
@@ -1,0 +1,24 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+using Tudormobile.FinancialData.Entities;
+using Tudormobile.FinancialData;
+
+namespace FinancialData.Tests.Entities
+{
+    [TestClass]
+    public class CryptoSymbolTests
+    {
+        [TestMethod]
+        public void CryptoSymbol_Deserialize_FromJson_Works()
+        {
+            var json = @"{
+    ""trading_symbol"": ""BTC-USD"",
+    ""name"": ""Bitcoin""
+}";
+            using var doc = JsonDocument.Parse(json);
+            var cryptoSymbol = FinancialDataSerializer.Instance.Deserialize<CryptoSymbol>(doc);
+            Assert.AreEqual("BTC-USD", cryptoSymbol.TradingSymbol);
+            Assert.AreEqual("Bitcoin", cryptoSymbol.Name);
+        }
+    }
+}

--- a/src/FinancialData.Tests/Entities/DividendTests.cs
+++ b/src/FinancialData.Tests/Entities/DividendTests.cs
@@ -13,14 +13,13 @@ namespace FinancialData.Tests.Entities
         {
             var json = @"{
     ""trading_symbol"": ""KO"",
-    ""central_index_key"": ""0000021344"",
     ""registrant_name"": ""COCA COLA CO"",
+    ""type"": ""Quarterly"",
+    ""amount"": 0.485,
     ""declaration_date"": ""2024-02-13"",
-    ""ex_dividend_date"": ""2024-03-14"",
+    ""ex_date"": ""2024-03-14"",
     ""record_date"": ""2024-03-15"",
-    ""payment_date"": ""2024-04-01"",
-    ""dividend_amount"": 0.485,
-    ""dividend_type"": ""Quarterly""
+    ""payment_date"": ""2024-04-01""
 }";
             using var doc = JsonDocument.Parse(json);
             var dividend = FinancialDataSerializer.Instance.Deserialize<Dividend>(doc);

--- a/src/FinancialData.Tests/Entities/DividendTests.cs
+++ b/src/FinancialData.Tests/Entities/DividendTests.cs
@@ -1,0 +1,32 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+using Tudormobile.FinancialData.Entities;
+using Tudormobile.FinancialData;
+
+namespace FinancialData.Tests.Entities
+{
+    [TestClass]
+    public class DividendTests
+    {
+        [TestMethod]
+        public void Dividend_Deserialize_FromJson_Works()
+        {
+            var json = @"{
+    ""trading_symbol"": ""KO"",
+    ""central_index_key"": ""0000021344"",
+    ""registrant_name"": ""COCA COLA CO"",
+    ""declaration_date"": ""2024-02-13"",
+    ""ex_dividend_date"": ""2024-03-14"",
+    ""record_date"": ""2024-03-15"",
+    ""payment_date"": ""2024-04-01"",
+    ""dividend_amount"": 0.485,
+    ""dividend_type"": ""Quarterly""
+}";
+            using var doc = JsonDocument.Parse(json);
+            var dividend = FinancialDataSerializer.Instance.Deserialize<Dividend>(doc);
+            Assert.AreEqual("KO", dividend.TradingSymbol);
+            Assert.AreEqual(0.485m, dividend.Amount);
+            Assert.AreEqual("Quarterly", dividend.Type);
+        }
+    }
+}

--- a/src/FinancialData.Tests/Entities/DividendsCalendarTests.cs
+++ b/src/FinancialData.Tests/Entities/DividendsCalendarTests.cs
@@ -13,13 +13,14 @@ namespace FinancialData.Tests.Entities
         {
             var json = @"{
     ""trading_symbol"": ""JNJ"",
-    ""central_index_key"": ""0000200406"",
     ""registrant_name"": ""JOHNSON & JOHNSON"",
     ""ex_dividend_date"": ""2024-02-26""
 }";
             using var doc = JsonDocument.Parse(json);
             var calendar = FinancialDataSerializer.Instance.Deserialize<DividendsCalendar>(doc);
             Assert.AreEqual("JNJ", calendar.TradingSymbol);
+            Assert.AreEqual("JOHNSON & JOHNSON", calendar.RegistrantName);
+            Assert.AreEqual(new DateOnly(2024, 2, 26), calendar.ExDividendDate);
         }
     }
 }

--- a/src/FinancialData.Tests/Entities/DividendsCalendarTests.cs
+++ b/src/FinancialData.Tests/Entities/DividendsCalendarTests.cs
@@ -1,0 +1,25 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+using Tudormobile.FinancialData.Entities;
+using Tudormobile.FinancialData;
+
+namespace FinancialData.Tests.Entities
+{
+    [TestClass]
+    public class DividendsCalendarTests
+    {
+        [TestMethod]
+        public void DividendsCalendar_Deserialize_FromJson_Works()
+        {
+            var json = @"{
+    ""trading_symbol"": ""JNJ"",
+    ""central_index_key"": ""0000200406"",
+    ""registrant_name"": ""JOHNSON & JOHNSON"",
+    ""ex_dividend_date"": ""2024-02-26""
+}";
+            using var doc = JsonDocument.Parse(json);
+            var calendar = FinancialDataSerializer.Instance.Deserialize<DividendsCalendar>(doc);
+            Assert.AreEqual("JNJ", calendar.TradingSymbol);
+        }
+    }
+}

--- a/src/FinancialData.Tests/Entities/EarningsCalendarTests.cs
+++ b/src/FinancialData.Tests/Entities/EarningsCalendarTests.cs
@@ -1,0 +1,25 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+using Tudormobile.FinancialData.Entities;
+using Tudormobile.FinancialData;
+
+namespace FinancialData.Tests.Entities
+{
+    [TestClass]
+    public class EarningsCalendarTests
+    {
+        [TestMethod]
+        public void EarningsCalendar_Deserialize_FromJson_Works()
+        {
+            var json = @"{
+    ""trading_symbol"": ""AAPL"",
+    ""central_index_key"": ""0000320193"",
+    ""registrant_name"": ""Apple Inc."",
+    ""earnings_date"": ""2024-02-01""
+}";
+            using var doc = JsonDocument.Parse(json);
+            var calendar = FinancialDataSerializer.Instance.Deserialize<EarningsCalendar>(doc);
+            Assert.AreEqual("AAPL", calendar.TradingSymbol);
+        }
+    }
+}

--- a/src/FinancialData.Tests/Entities/EarningsCalendarTests.cs
+++ b/src/FinancialData.Tests/Entities/EarningsCalendarTests.cs
@@ -13,13 +13,14 @@ namespace FinancialData.Tests.Entities
         {
             var json = @"{
     ""trading_symbol"": ""AAPL"",
-    ""central_index_key"": ""0000320193"",
     ""registrant_name"": ""Apple Inc."",
-    ""earnings_date"": ""2024-02-01""
+    ""report_date"": ""2024-02-01""
 }";
             using var doc = JsonDocument.Parse(json);
             var calendar = FinancialDataSerializer.Instance.Deserialize<EarningsCalendar>(doc);
             Assert.AreEqual("AAPL", calendar.TradingSymbol);
+            Assert.AreEqual("Apple Inc.", calendar.RegistrantName);
+            Assert.AreEqual(new DateOnly(2024, 2, 1), calendar.ReportDate);
         }
     }
 }

--- a/src/FinancialData.Tests/Entities/EarningsReleaseTests.cs
+++ b/src/FinancialData.Tests/Entities/EarningsReleaseTests.cs
@@ -1,0 +1,35 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+using Tudormobile.FinancialData.Entities;
+using Tudormobile.FinancialData;
+
+namespace FinancialData.Tests.Entities
+{
+    [TestClass]
+    public class EarningsReleaseTests
+    {
+        [TestMethod]
+        public void EarningsRelease_Deserialize_FromJson_Works()
+        {
+            var json = @"{
+    ""trading_symbol"": ""NVDA"",
+    ""central_index_key"": ""0001045810"",
+    ""registrant_name"": ""NVIDIA CORP"",
+    ""fiscal_year"": ""2024"",
+    ""fiscal_quarter"": ""Q4"",
+    ""period_end_date"": ""2024-01-28"",
+    ""earnings_date"": ""2024-02-21"",
+    ""eps_actual"": 5.16,
+    ""eps_forecast"": 4.64,
+    ""number_of_forecasts"": 35,
+    ""conference_call_time"": ""2024-02-21 17:00:00""
+}";
+            using var doc = JsonDocument.Parse(json);
+            var earnings = FinancialDataSerializer.Instance.Deserialize<EarningsRelease>(doc);
+            Assert.AreEqual("NVDA", earnings.TradingSymbol);
+            Assert.AreEqual(5.16m, earnings.EarningsPerShare);
+            Assert.AreEqual(4.64m, earnings.EarningsPerShareForecast);
+            Assert.AreEqual(35, earnings.NumberOfForecasts);
+        }
+    }
+}

--- a/src/FinancialData.Tests/Entities/EarningsReleaseTests.cs
+++ b/src/FinancialData.Tests/Entities/EarningsReleaseTests.cs
@@ -15,12 +15,11 @@ namespace FinancialData.Tests.Entities
     ""trading_symbol"": ""NVDA"",
     ""central_index_key"": ""0001045810"",
     ""registrant_name"": ""NVIDIA CORP"",
-    ""fiscal_year"": ""2024"",
-    ""fiscal_quarter"": ""Q4"",
-    ""period_end_date"": ""2024-01-28"",
-    ""earnings_date"": ""2024-02-21"",
-    ""eps_actual"": 5.16,
-    ""eps_forecast"": 4.64,
+    ""market_cap"": 1500000000000.0,
+    ""fiscal_quarter_end_date"": ""2024-01-28"",
+    ""earnings_per_share"": 5.16,
+    ""earnings_per_share_forecast"": 4.64,
+    ""percentage_surprise"": 11.2,
     ""number_of_forecasts"": 35,
     ""conference_call_time"": ""2024-02-21 17:00:00""
 }";

--- a/src/FinancialData.Tests/Entities/EconomicCalendarTests.cs
+++ b/src/FinancialData.Tests/Entities/EconomicCalendarTests.cs
@@ -12,13 +12,12 @@ namespace FinancialData.Tests.Entities
         public void EconomicCalendar_Deserialize_FromJson_Works()
         {
             var json = @"{
-    ""event_date"": ""2024-02-15"",
-    ""event_time"": ""08:30:00"",
-    ""country"": ""United States"",
     ""event_name"": ""CPI Release"",
-    ""actual"": 3.1,
-    ""forecast"": 2.9,
-    ""previous"": 3.4
+    ""country"": ""United States"",
+    ""country_code"": ""US"",
+    ""time"": ""2024-02-15 08:30:00"",
+    ""previous_value"": 3.4,
+    ""actual_value"": 3.1
 }";
             using var doc = JsonDocument.Parse(json);
             var calendar = FinancialDataSerializer.Instance.Deserialize<EconomicCalendar>(doc);

--- a/src/FinancialData.Tests/Entities/EconomicCalendarTests.cs
+++ b/src/FinancialData.Tests/Entities/EconomicCalendarTests.cs
@@ -1,0 +1,30 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+using Tudormobile.FinancialData.Entities;
+using Tudormobile.FinancialData;
+
+namespace FinancialData.Tests.Entities
+{
+    [TestClass]
+    public class EconomicCalendarTests
+    {
+        [TestMethod]
+        public void EconomicCalendar_Deserialize_FromJson_Works()
+        {
+            var json = @"{
+    ""event_date"": ""2024-02-15"",
+    ""event_time"": ""08:30:00"",
+    ""country"": ""United States"",
+    ""event_name"": ""CPI Release"",
+    ""actual"": 3.1,
+    ""forecast"": 2.9,
+    ""previous"": 3.4
+}";
+            using var doc = JsonDocument.Parse(json);
+            var calendar = FinancialDataSerializer.Instance.Deserialize<EconomicCalendar>(doc);
+            Assert.AreEqual("United States", calendar.Country);
+            Assert.AreEqual("CPI Release", calendar.EventName);
+            Assert.AreEqual(3.1m, calendar.ActualValue);
+        }
+    }
+}

--- a/src/FinancialData.Tests/Entities/EmployeeCountTests.cs
+++ b/src/FinancialData.Tests/Entities/EmployeeCountTests.cs
@@ -16,7 +16,7 @@ namespace FinancialData.Tests.Entities
     ""central_index_key"": ""0001652044"",
     ""registrant_name"": ""Alphabet Inc."",
     ""fiscal_year"": ""2023"",
-    ""number_of_employees"": 182502
+    ""count"": 182502
 }";
             using var doc = JsonDocument.Parse(json);
             var employeeCount = FinancialDataSerializer.Instance.Deserialize<EmployeeCount>(doc);

--- a/src/FinancialData.Tests/Entities/EmployeeCountTests.cs
+++ b/src/FinancialData.Tests/Entities/EmployeeCountTests.cs
@@ -1,0 +1,28 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+using Tudormobile.FinancialData.Entities;
+using Tudormobile.FinancialData;
+
+namespace FinancialData.Tests.Entities
+{
+    [TestClass]
+    public class EmployeeCountTests
+    {
+        [TestMethod]
+        public void EmployeeCount_Deserialize_FromJson_Works()
+        {
+            var json = @"{
+    ""trading_symbol"": ""GOOGL"",
+    ""central_index_key"": ""0001652044"",
+    ""registrant_name"": ""Alphabet Inc."",
+    ""fiscal_year"": ""2023"",
+    ""number_of_employees"": 182502
+}";
+            using var doc = JsonDocument.Parse(json);
+            var employeeCount = FinancialDataSerializer.Instance.Deserialize<EmployeeCount>(doc);
+            Assert.AreEqual("GOOGL", employeeCount.TradingSymbol);
+            Assert.AreEqual("2023", employeeCount.FiscalYear);
+            Assert.AreEqual(182502, employeeCount.Count);
+        }
+    }
+}

--- a/src/FinancialData.Tests/Entities/EsgRatingTests.cs
+++ b/src/FinancialData.Tests/Entities/EsgRatingTests.cs
@@ -1,0 +1,32 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+using Tudormobile.FinancialData.Entities;
+using Tudormobile.FinancialData;
+
+namespace FinancialData.Tests.Entities
+{
+    [TestClass]
+    public class EsgRatingTests
+    {
+        [TestMethod]
+        public void EsgRating_Deserialize_FromJson_Works()
+        {
+            var json = @"{
+    ""trading_symbol"": ""MSFT"",
+    ""central_index_key"": ""0000789019"",
+    ""registrant_name"": ""MICROSOFT CORP"",
+    ""date"": ""2024-01-15"",
+    ""rating"": ""AAA"",
+    ""environmental_rating"": ""AA"",
+    ""social_rating"": ""AAA"",
+    ""governance_rating"": ""AA""
+}";
+            using var doc = JsonDocument.Parse(json);
+            var esgRating = FinancialDataSerializer.Instance.Deserialize<EsgRating>(doc);
+            Assert.AreEqual("MSFT", esgRating.TradingSymbol);
+            Assert.AreEqual("AAA", esgRating.Rating);
+            Assert.AreEqual("AA", esgRating.EnvironmentalRating);
+            Assert.AreEqual("AAA", esgRating.SocialRating);
+        }
+    }
+}

--- a/src/FinancialData.Tests/Entities/EsgRatingTests.cs
+++ b/src/FinancialData.Tests/Entities/EsgRatingTests.cs
@@ -24,9 +24,13 @@ namespace FinancialData.Tests.Entities
             using var doc = JsonDocument.Parse(json);
             var esgRating = FinancialDataSerializer.Instance.Deserialize<EsgRating>(doc);
             Assert.AreEqual("MSFT", esgRating.TradingSymbol);
+            Assert.AreEqual("0000789019", esgRating.CentralIndexKey);
+            Assert.AreEqual("MICROSOFT CORP", esgRating.RegistrantName);
+            Assert.AreEqual(new DateOnly(2024, 1, 15), esgRating.Date);
             Assert.AreEqual("AAA", esgRating.Rating);
             Assert.AreEqual("AA", esgRating.EnvironmentalRating);
             Assert.AreEqual("AAA", esgRating.SocialRating);
+            Assert.AreEqual("AA", esgRating.GovernanceRating);
         }
     }
 }

--- a/src/FinancialData.Tests/Entities/EsgScoreTests.cs
+++ b/src/FinancialData.Tests/Entities/EsgScoreTests.cs
@@ -1,0 +1,35 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+using Tudormobile.FinancialData.Entities;
+using Tudormobile.FinancialData;
+
+namespace FinancialData.Tests.Entities
+{
+    [TestClass]
+    public class EsgScoreTests
+    {
+        [TestMethod]
+        public void EsgScore_Deserialize_FromJson_Works()
+        {
+            var json = @"{
+    ""trading_symbol"": ""AAPL"",
+    ""central_index_key"": ""0000320193"",
+    ""registrant_name"": ""Apple Inc."",
+    ""date"": ""2024-01-15"",
+    ""total_score"": 82.5,
+    ""environmental_score"": 85.0,
+    ""social_score"": 80.0,
+    ""governance_score"": 83.0,
+    ""controversy_score"": 2.0
+}";
+            using var doc = JsonDocument.Parse(json);
+            var esgScore = FinancialDataSerializer.Instance.Deserialize<EsgScore>(doc);
+            Assert.AreEqual("AAPL", esgScore.TradingSymbol);
+            Assert.AreEqual(82.5m, esgScore.TotalScore);
+            Assert.AreEqual(85.0m, esgScore.EnvironmentalScore);
+            Assert.AreEqual(80.0m, esgScore.SocialScore);
+            Assert.AreEqual(83.0m, esgScore.GovernanceScore);
+            Assert.AreEqual(2.0m, esgScore.ControversyScore);
+        }
+    }
+}

--- a/src/FinancialData.Tests/Entities/EtfHoldingsTests.cs
+++ b/src/FinancialData.Tests/Entities/EtfHoldingsTests.cs
@@ -1,0 +1,52 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+using Tudormobile.FinancialData.Entities;
+using Tudormobile.FinancialData;
+
+namespace FinancialData.Tests.Entities
+{
+    [TestClass]
+    public class EtfHoldingsTests
+    {
+        [TestMethod]
+        public void EtfHoldings_Deserialize_FromJson_Works()
+        {
+            var json = @"{
+    ""central_index_key"": ""0000884394"",
+    ""registrant_name"": ""SPDR S&P 500 ETF TRUST"",
+    ""period_of_report"": ""2025-06-30"",
+    ""etf_name"": ""SPDR S&P 500 ETF TRUST"",
+    ""etf_symbol"": ""SPY"",
+    ""series_id"": ""N/A"",
+    ""class_id"": ""N/A"",
+    ""issuer_name"": ""Johnson & Johnson"",
+    ""lei_number"": ""549300G0CFPGEF6X2043"",
+    ""title_of_security"": ""Johnson & Johnson"",
+    ""trading_symbol"": ""JNJ"",
+    ""cusip_number"": ""478160104"",
+    ""isin_number"": ""US4781601046"",
+    ""amount_of_units"": 29181009,
+    ""description_of_units"": ""NS"",
+    ""denomination_currency"": ""USD"",
+    ""value_in_usd"": 4457399124.75,
+    ""percentage_value_compared_to_assets"": 0.699985772661,
+    ""payoff_profile"": ""Long"",
+    ""asset_type"": ""EC"",
+    ""issuer_type"": ""CORP"",
+    ""country_of_issuer_or_investment"": ""US"",
+    ""is_restricted_security"": false,
+    ""fair_value_level"": 1,
+    ""is_cash_collateral"": false,
+    ""is_non_cash_collateral"": false,
+    ""is_loan_by_fund"": false
+}";
+            using var doc = JsonDocument.Parse(json);
+            var etfHoldings = FinancialDataSerializer.Instance.Deserialize<EtfHoldings>(doc);
+            Assert.AreEqual("0000884394", etfHoldings.CentralIndexKey);
+            Assert.AreEqual("SPY", etfHoldings.EtfSymbol);
+            Assert.AreEqual("JNJ", etfHoldings.TradingSymbol);
+            Assert.AreEqual(4457399124.75m, etfHoldings.ValueInUsd);
+            Assert.AreEqual(false, etfHoldings.IsRestrictedSecurity);
+        }
+    }
+}

--- a/src/FinancialData.Tests/Entities/EtfPricesTests.cs
+++ b/src/FinancialData.Tests/Entities/EtfPricesTests.cs
@@ -1,0 +1,32 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+using Tudormobile.FinancialData.Entities;
+using Tudormobile.FinancialData;
+
+namespace FinancialData.Tests.Entities
+{
+    [TestClass]
+    public class EtfPricesTests
+    {
+        [TestMethod]
+        public void EtfPrices_Deserialize_FromJson_Works()
+        {
+            var json = @"{
+    ""trading_symbol"": ""SPY"",
+    ""date"": ""2024-12-03"",
+    ""open"": 603.39,
+    ""high"": 604.16,
+    ""low"": 602.341,
+    ""close"": 603.91,
+    ""volume"": 26906630.0
+}";
+            using var doc = JsonDocument.Parse(json);
+            var etfPrices = FinancialDataSerializer.Instance.Deserialize<EtfPrices>(doc);
+            Assert.AreEqual("SPY", etfPrices.TradingSymbol);
+            Assert.AreEqual(new DateOnly(2024, 12, 3), etfPrices.Date);
+            Assert.AreEqual(603.39m, etfPrices.Open);
+            Assert.AreEqual(604.16m, etfPrices.High);
+            Assert.AreEqual(603.91m, etfPrices.Close);
+        }
+    }
+}

--- a/src/FinancialData.Tests/Entities/EtfQuotesTests.cs
+++ b/src/FinancialData.Tests/Entities/EtfQuotesTests.cs
@@ -1,0 +1,31 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+using Tudormobile.FinancialData.Entities;
+using Tudormobile.FinancialData;
+
+namespace FinancialData.Tests.Entities
+{
+    [TestClass]
+    public class EtfQuotesTests
+    {
+        [TestMethod]
+        public void EtfQuotes_Deserialize_FromJson_Works()
+        {
+            var json = @"{
+    ""trading_symbol"": ""SPY"",
+    ""description"": ""SPDR S&P 500 ETF Trust"",
+    ""time"": ""2025-09-02 15:59:30"",
+    ""price"": 642.41,
+    ""change"": 2.14,
+    ""percentage_change"": 0.33
+}";
+            using var doc = JsonDocument.Parse(json);
+            var etfQuotes = FinancialDataSerializer.Instance.Deserialize<EtfQuotes>(doc);
+            Assert.AreEqual("SPY", etfQuotes.TradingSymbol);
+            Assert.AreEqual("SPDR S&P 500 ETF Trust", etfQuotes.Description);
+            Assert.AreEqual(642.41m, etfQuotes.Price);
+            Assert.AreEqual(2.14m, etfQuotes.Change);
+            Assert.AreEqual(0.33m, etfQuotes.PercentageChange);
+        }
+    }
+}

--- a/src/FinancialData.Tests/Entities/ExecutiveCompensationTests.cs
+++ b/src/FinancialData.Tests/Entities/ExecutiveCompensationTests.cs
@@ -1,0 +1,37 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+using Tudormobile.FinancialData.Entities;
+using Tudormobile.FinancialData;
+
+namespace FinancialData.Tests.Entities
+{
+    [TestClass]
+    public class ExecutiveCompensationTests
+    {
+        [TestMethod]
+        public void ExecutiveCompensation_Deserialize_FromJson_Works()
+        {
+            var json = @"{
+    ""trading_symbol"": ""AAPL"",
+    ""central_index_key"": ""0000320193"",
+    ""registrant_name"": ""Apple Inc."",
+    ""fiscal_year"": ""2023"",
+    ""executive_name"": ""Tim Cook"",
+    ""executive_title"": ""CEO"",
+    ""salary"": 3000000.0,
+    ""bonus"": 12000000.0,
+    ""stock_awards"": 82000000.0,
+    ""option_awards"": 0.0,
+    ""non_equity_incentive_plan_compensation"": 10000000.0,
+    ""all_other_compensation"": 1500000.0,
+    ""total_compensation"": 108500000.0
+}";
+            using var doc = JsonDocument.Parse(json);
+            var compensation = FinancialDataSerializer.Instance.Deserialize<ExecutiveCompensation>(doc);
+            Assert.AreEqual("AAPL", compensation.TradingSymbol);
+            Assert.AreEqual("Tim Cook", compensation.ExecutiveName);
+            Assert.AreEqual(3000000m, compensation.Salary);
+            Assert.AreEqual(108500000m, compensation.TotalCompensation);
+        }
+    }
+}

--- a/src/FinancialData.Tests/Entities/FedPressReleaseTests.cs
+++ b/src/FinancialData.Tests/Entities/FedPressReleaseTests.cs
@@ -19,7 +19,9 @@ namespace FinancialData.Tests.Entities
 }";
             using var doc = JsonDocument.Parse(json);
             var fedPressRelease = FinancialDataSerializer.Instance.Deserialize<FedPressRelease>(doc);
+            Assert.AreEqual(new DateTime(2024, 1, 31, 14, 0, 0), fedPressRelease.DateTime);
             Assert.AreEqual("Federal Reserve maintains target range for federal funds rate", fedPressRelease.Headline);
+            Assert.AreEqual("The Federal Open Market Committee decided today...", fedPressRelease.Text);
             Assert.AreEqual("https://www.federalreserve.gov/newsevents/pressreleases/", fedPressRelease.Url);
         }
     }

--- a/src/FinancialData.Tests/Entities/FedPressReleaseTests.cs
+++ b/src/FinancialData.Tests/Entities/FedPressReleaseTests.cs
@@ -1,0 +1,26 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+using Tudormobile.FinancialData.Entities;
+using Tudormobile.FinancialData;
+
+namespace FinancialData.Tests.Entities
+{
+    [TestClass]
+    public class FedPressReleaseTests
+    {
+        [TestMethod]
+        public void FedPressRelease_Deserialize_FromJson_Works()
+        {
+            var json = @"{
+    ""date_time"": ""2024-01-31 14:00:00"",
+    ""headline"": ""Federal Reserve maintains target range for federal funds rate"",
+    ""text"": ""The Federal Open Market Committee decided today..."",
+    ""url"": ""https://www.federalreserve.gov/newsevents/pressreleases/""
+}";
+            using var doc = JsonDocument.Parse(json);
+            var fedPressRelease = FinancialDataSerializer.Instance.Deserialize<FedPressRelease>(doc);
+            Assert.AreEqual("Federal Reserve maintains target range for federal funds rate", fedPressRelease.Headline);
+            Assert.AreEqual("https://www.federalreserve.gov/newsevents/pressreleases/", fedPressRelease.Url);
+        }
+    }
+}

--- a/src/FinancialData.Tests/Entities/ForexMinutePriceTests.cs
+++ b/src/FinancialData.Tests/Entities/ForexMinutePriceTests.cs
@@ -1,0 +1,30 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+using Tudormobile.FinancialData.Entities;
+using Tudormobile.FinancialData;
+
+namespace FinancialData.Tests.Entities
+{
+    [TestClass]
+    public class ForexMinutePriceTests
+    {
+        [TestMethod]
+        public void ForexMinutePrice_Deserialize_FromJson_Works()
+        {
+            var json = @"{
+    ""trading_symbol"": ""EUR/USD"",
+    ""time"": ""2024-01-15 14:30:00"",
+    ""open"": 1.0890,
+    ""high"": 1.0893,
+    ""low"": 1.0888,
+    ""close"": 1.0891
+}";
+            using var doc = JsonDocument.Parse(json);
+            var forexMinutePrice = FinancialDataSerializer.Instance.Deserialize<ForexMinutePrice>(doc);
+            Assert.AreEqual("EUR/USD", forexMinutePrice.TradingSymbol);
+            Assert.AreEqual(1.0890m, forexMinutePrice.Open);
+            Assert.AreEqual(1.0893m, forexMinutePrice.High);
+            Assert.AreEqual(1.0891m, forexMinutePrice.Close);
+        }
+    }
+}

--- a/src/FinancialData.Tests/Entities/ForexPriceTests.cs
+++ b/src/FinancialData.Tests/Entities/ForexPriceTests.cs
@@ -1,0 +1,30 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+using Tudormobile.FinancialData.Entities;
+using Tudormobile.FinancialData;
+
+namespace FinancialData.Tests.Entities
+{
+    [TestClass]
+    public class ForexPriceTests
+    {
+        [TestMethod]
+        public void ForexPrice_Deserialize_FromJson_Works()
+        {
+            var json = @"{
+    ""trading_symbol"": ""GBP/USD"",
+    ""date"": ""2024-01-15"",
+    ""open"": 1.2650,
+    ""high"": 1.2680,
+    ""low"": 1.2640,
+    ""close"": 1.2675
+}";
+            using var doc = JsonDocument.Parse(json);
+            var forexPrice = FinancialDataSerializer.Instance.Deserialize<ForexPrice>(doc);
+            Assert.AreEqual("GBP/USD", forexPrice.TradingSymbol);
+            Assert.AreEqual(1.2650m, forexPrice.Open);
+            Assert.AreEqual(1.2680m, forexPrice.High);
+            Assert.AreEqual(1.2675m, forexPrice.Close);
+        }
+    }
+}

--- a/src/FinancialData.Tests/Entities/ForexQuoteTests.cs
+++ b/src/FinancialData.Tests/Entities/ForexQuoteTests.cs
@@ -1,0 +1,29 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+using Tudormobile.FinancialData.Entities;
+using Tudormobile.FinancialData;
+
+namespace FinancialData.Tests.Entities
+{
+    [TestClass]
+    public class ForexQuoteTests
+    {
+        [TestMethod]
+        public void ForexQuote_Deserialize_FromJson_Works()
+        {
+            var json = @"{
+    ""trading_symbol"": ""EUR/USD"",
+    ""time"": ""2024-01-15 14:30:00"",
+    ""bid"": 1.0890,
+    ""ask"": 1.0892,
+    ""rate"": 1.0891
+}";
+            using var doc = JsonDocument.Parse(json);
+            var forexQuote = FinancialDataSerializer.Instance.Deserialize<ForexQuote>(doc);
+            Assert.AreEqual("EUR/USD", forexQuote.TradingSymbol);
+            Assert.AreEqual(1.0890m, forexQuote.Bid);
+            Assert.AreEqual(1.0892m, forexQuote.Ask);
+            Assert.AreEqual(1.0891m, forexQuote.Rate);
+        }
+    }
+}

--- a/src/FinancialData.Tests/Entities/ForexSymbolTests.cs
+++ b/src/FinancialData.Tests/Entities/ForexSymbolTests.cs
@@ -1,0 +1,24 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+using Tudormobile.FinancialData.Entities;
+using Tudormobile.FinancialData;
+
+namespace FinancialData.Tests.Entities
+{
+    [TestClass]
+    public class ForexSymbolTests
+    {
+        [TestMethod]
+        public void ForexSymbol_Deserialize_FromJson_Works()
+        {
+            var json = @"{
+    ""trading_symbol"": ""EUR/USD"",
+    ""name"": ""Euro / US Dollar""
+}";
+            using var doc = JsonDocument.Parse(json);
+            var forexSymbol = FinancialDataSerializer.Instance.Deserialize<ForexSymbol>(doc);
+            Assert.AreEqual("EUR/USD", forexSymbol.TradingSymbol);
+            Assert.AreEqual("Euro / US Dollar", forexSymbol.Name);
+        }
+    }
+}

--- a/src/FinancialData.Tests/Entities/FuturesPriceTests.cs
+++ b/src/FinancialData.Tests/Entities/FuturesPriceTests.cs
@@ -1,0 +1,31 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+using Tudormobile.FinancialData.Entities;
+using Tudormobile.FinancialData;
+
+namespace FinancialData.Tests.Entities
+{
+    [TestClass]
+    public class FuturesPriceTests
+    {
+        [TestMethod]
+        public void FuturesPrice_Deserialize_FromJson_Works()
+        {
+            var json = @"{
+    ""trading_symbol"": ""ES"",
+    ""date"": ""2024-01-15"",
+    ""open"": 4800.50,
+    ""high"": 4825.75,
+    ""low"": 4795.25,
+    ""close"": 4820.00,
+    ""volume"": 2500000
+}";
+            using var doc = JsonDocument.Parse(json);
+            var futuresPrice = FinancialDataSerializer.Instance.Deserialize<FuturesPrice>(doc);
+            Assert.AreEqual("ES", futuresPrice.TradingSymbol);
+            Assert.AreEqual(4800.50m, futuresPrice.Open);
+            Assert.AreEqual(4825.75m, futuresPrice.High);
+            Assert.AreEqual(4820.00m, futuresPrice.Close);
+        }
+    }
+}

--- a/src/FinancialData.Tests/Entities/FuturesSymbolTests.cs
+++ b/src/FinancialData.Tests/Entities/FuturesSymbolTests.cs
@@ -1,0 +1,26 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+using Tudormobile.FinancialData.Entities;
+using Tudormobile.FinancialData;
+
+namespace FinancialData.Tests.Entities
+{
+    [TestClass]
+    public class FuturesSymbolTests
+    {
+        [TestMethod]
+        public void FuturesSymbol_Deserialize_FromJson_Works()
+        {
+            var json = @"{
+    ""trading_symbol"": ""ES"",
+    ""description"": ""E-mini S&P 500 Futures"",
+    ""type"": ""Index Futures""
+}";
+            using var doc = JsonDocument.Parse(json);
+            var futuresSymbol = FinancialDataSerializer.Instance.Deserialize<FuturesSymbol>(doc);
+            Assert.AreEqual("ES", futuresSymbol.TradingSymbol);
+            Assert.AreEqual("E-mini S&P 500 Futures", futuresSymbol.Description);
+            Assert.AreEqual("Index Futures", futuresSymbol.Type);
+        }
+    }
+}

--- a/src/FinancialData.Tests/Entities/HouseTradingTests.cs
+++ b/src/FinancialData.Tests/Entities/HouseTradingTests.cs
@@ -25,7 +25,12 @@ namespace FinancialData.Tests.Entities
             var houseTrading = FinancialDataSerializer.Instance.Deserialize<HouseTrading>(doc);
             Assert.AreEqual("MSFT", houseTrading.TradingSymbol);
             Assert.AreEqual("Jane Smith", houseTrading.RepresentativeName);
+            Assert.AreEqual(new DateOnly(2024, 1, 12), houseTrading.TransactionDate);
+            Assert.AreEqual(new DateOnly(2024, 1, 30), houseTrading.DisclosureDate);
             Assert.AreEqual("Sale", houseTrading.TransactionType);
+            Assert.AreEqual("Stock", houseTrading.AssetType);
+            Assert.AreEqual("$50,001 - $100,000", houseTrading.AmountRange);
+            Assert.AreEqual("", houseTrading.Comment);
         }
     }
 }

--- a/src/FinancialData.Tests/Entities/HouseTradingTests.cs
+++ b/src/FinancialData.Tests/Entities/HouseTradingTests.cs
@@ -1,0 +1,31 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+using Tudormobile.FinancialData.Entities;
+using Tudormobile.FinancialData;
+
+namespace FinancialData.Tests.Entities
+{
+    [TestClass]
+    public class HouseTradingTests
+    {
+        [TestMethod]
+        public void HouseTrading_Deserialize_FromJson_Works()
+        {
+            var json = @"{
+    ""trading_symbol"": ""MSFT"",
+    ""representative_name"": ""Jane Smith"",
+    ""transaction_date"": ""2024-01-12"",
+    ""disclosure_date"": ""2024-01-30"",
+    ""transaction_type"": ""Sale"",
+    ""asset_type"": ""Stock"",
+    ""amount_range"": ""$50,001 - $100,000"",
+    ""comment"": """"
+}";
+            using var doc = JsonDocument.Parse(json);
+            var houseTrading = FinancialDataSerializer.Instance.Deserialize<HouseTrading>(doc);
+            Assert.AreEqual("MSFT", houseTrading.TradingSymbol);
+            Assert.AreEqual("Jane Smith", houseTrading.RepresentativeName);
+            Assert.AreEqual("Sale", houseTrading.TransactionType);
+        }
+    }
+}

--- a/src/FinancialData.Tests/Entities/IndexConstituentTests.cs
+++ b/src/FinancialData.Tests/Entities/IndexConstituentTests.cs
@@ -1,0 +1,33 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+using Tudormobile.FinancialData.Entities;
+using Tudormobile.FinancialData;
+
+namespace FinancialData.Tests.Entities
+{
+    [TestClass]
+    public class IndexConstituentTests
+    {
+        [TestMethod]
+        public void IndexConstituent_Deserialize_FromJson_Works()
+        {
+            var json = @"{
+    ""trading_symbol"": ""^GSPC"",
+    ""index_name"": ""S&P 500"",
+    ""constituent_symbol"": ""COIN"",
+    ""constituent_name"": ""Coinbase"",
+    ""sector"": ""Financials"",
+    ""industry"": ""Financial Exchanges & Data"",
+    ""date_added"": ""2025-05-19""
+}";
+            using var doc = JsonDocument.Parse(json);
+            var indexConstituent = FinancialDataSerializer.Instance.Deserialize<IndexConstituent>(doc);
+            Assert.AreEqual("^GSPC", indexConstituent.TradingSymbol);
+            Assert.AreEqual("S&P 500", indexConstituent.IndexName);
+            Assert.AreEqual("COIN", indexConstituent.ConstituentSymbol);
+            Assert.AreEqual("Coinbase", indexConstituent.ConstituentName);
+            Assert.AreEqual("Financials", indexConstituent.Sector);
+            Assert.AreEqual(new DateOnly(2025, 5, 19), indexConstituent.DateAdded);
+        }
+    }
+}

--- a/src/FinancialData.Tests/Entities/IndexPriceTests.cs
+++ b/src/FinancialData.Tests/Entities/IndexPriceTests.cs
@@ -1,0 +1,32 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+using Tudormobile.FinancialData.Entities;
+using Tudormobile.FinancialData;
+
+namespace FinancialData.Tests.Entities
+{
+    [TestClass]
+    public class IndexPriceTests
+    {
+        [TestMethod]
+        public void IndexPrice_Deserialize_FromJson_Works()
+        {
+            var json = @"{
+    ""trading_symbol"": ""^GSPC"",
+    ""date"": ""2025-06-13"",
+    ""open"": 6000.56,
+    ""high"": 6026.16,
+    ""low"": 5963.21,
+    ""close"": 5976.97,
+    ""volume"": 5258910000.0
+}";
+            using var doc = JsonDocument.Parse(json);
+            var indexPrice = FinancialDataSerializer.Instance.Deserialize<IndexPrice>(doc);
+            Assert.AreEqual("^GSPC", indexPrice.TradingSymbol);
+            Assert.AreEqual(new DateOnly(2025, 6, 13), indexPrice.Date);
+            Assert.AreEqual(6000.56m, indexPrice.Open);
+            Assert.AreEqual(6026.16m, indexPrice.High);
+            Assert.AreEqual(5976.97m, indexPrice.Close);
+        }
+    }
+}

--- a/src/FinancialData.Tests/Entities/IndexQuoteTests.cs
+++ b/src/FinancialData.Tests/Entities/IndexQuoteTests.cs
@@ -1,0 +1,31 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+using Tudormobile.FinancialData.Entities;
+using Tudormobile.FinancialData;
+
+namespace FinancialData.Tests.Entities
+{
+    [TestClass]
+    public class IndexQuoteTests
+    {
+        [TestMethod]
+        public void IndexQuote_Deserialize_FromJson_Works()
+        {
+            var json = @"{
+    ""trading_symbol"": ""^GSPC"",
+    ""index_name"": ""S&P 500"",
+    ""time"": ""2025-09-23 15:19:59"",
+    ""price"": 6656.92,
+    ""change"": -36.83,
+    ""percentage_change"": -0.55
+}";
+            using var doc = JsonDocument.Parse(json);
+            var indexQuote = FinancialDataSerializer.Instance.Deserialize<IndexQuote>(doc);
+            Assert.AreEqual("^GSPC", indexQuote.TradingSymbol);
+            Assert.AreEqual("S&P 500", indexQuote.IndexName);
+            Assert.AreEqual(6656.92m, indexQuote.Price);
+            Assert.AreEqual(-36.83m, indexQuote.Change);
+            Assert.AreEqual(-0.55m, indexQuote.PercentageChange);
+        }
+    }
+}

--- a/src/FinancialData.Tests/Entities/IndexSymbolTests.cs
+++ b/src/FinancialData.Tests/Entities/IndexSymbolTests.cs
@@ -1,0 +1,24 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+using Tudormobile.FinancialData.Entities;
+using Tudormobile.FinancialData;
+
+namespace FinancialData.Tests.Entities
+{
+    [TestClass]
+    public class IndexSymbolTests
+    {
+        [TestMethod]
+        public void IndexSymbol_Deserialize_FromJson_Works()
+        {
+            var json = @"{
+    ""trading_symbol"": ""000001.SS"",
+    ""index_name"": ""SSE Composite Index""
+}";
+            using var doc = JsonDocument.Parse(json);
+            var indexSymbol = FinancialDataSerializer.Instance.Deserialize<IndexSymbol>(doc);
+            Assert.AreEqual("000001.SS", indexSymbol.TradingSymbol);
+            Assert.AreEqual("SSE Composite Index", indexSymbol.IndexName);
+        }
+    }
+}

--- a/src/FinancialData.Tests/Entities/IndustryEsgScoreTests.cs
+++ b/src/FinancialData.Tests/Entities/IndustryEsgScoreTests.cs
@@ -24,8 +24,12 @@ namespace FinancialData.Tests.Entities
             using var doc = JsonDocument.Parse(json);
             var industryScore = FinancialDataSerializer.Instance.Deserialize<IndustryEsgScore>(doc);
             Assert.AreEqual("Technology", industryScore.Industry);
+            Assert.AreEqual(new DateOnly(2024, 1, 15), industryScore.Date);
             Assert.AreEqual(75.5m, industryScore.AverageTotalScore);
             Assert.AreEqual(72.3m, industryScore.AverageEnvironmentalScore);
+            Assert.AreEqual(78.2m, industryScore.AverageSocialScore);
+            Assert.AreEqual(76.1m, industryScore.AverageGovernanceScore);
+            Assert.AreEqual(3.2m, industryScore.AverageControversyScore);
             Assert.AreEqual(250, industryScore.NumberOfCompanies);
         }
     }

--- a/src/FinancialData.Tests/Entities/IndustryEsgScoreTests.cs
+++ b/src/FinancialData.Tests/Entities/IndustryEsgScoreTests.cs
@@ -1,0 +1,32 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+using Tudormobile.FinancialData.Entities;
+using Tudormobile.FinancialData;
+
+namespace FinancialData.Tests.Entities
+{
+    [TestClass]
+    public class IndustryEsgScoreTests
+    {
+        [TestMethod]
+        public void IndustryEsgScore_Deserialize_FromJson_Works()
+        {
+            var json = @"{
+    ""industry"": ""Technology"",
+    ""date"": ""2024-01-15"",
+    ""average_total_score"": 75.5,
+    ""average_environmental_score"": 72.3,
+    ""average_social_score"": 78.2,
+    ""average_governance_score"": 76.1,
+    ""average_controversy_score"": 3.2,
+    ""number_of_companies"": 250
+}";
+            using var doc = JsonDocument.Parse(json);
+            var industryScore = FinancialDataSerializer.Instance.Deserialize<IndustryEsgScore>(doc);
+            Assert.AreEqual("Technology", industryScore.Industry);
+            Assert.AreEqual(75.5m, industryScore.AverageTotalScore);
+            Assert.AreEqual(72.3m, industryScore.AverageEnvironmentalScore);
+            Assert.AreEqual(250, industryScore.NumberOfCompanies);
+        }
+    }
+}

--- a/src/FinancialData.Tests/Entities/InitialPublicOfferingTests.cs
+++ b/src/FinancialData.Tests/Entities/InitialPublicOfferingTests.cs
@@ -13,14 +13,12 @@ namespace FinancialData.Tests.Entities
         {
             var json = @"{
     ""trading_symbol"": ""ABNB"",
-    ""central_index_key"": ""0001559720"",
     ""registrant_name"": ""Airbnb, Inc."",
-    ""ipo_date"": ""2020-12-10"",
-    ""offer_price"": 68.00,
+    ""exchange"": ""NASDAQ"",
+    ""pricing_date"": ""2020-12-10"",
+    ""share_price"": 68.00,
     ""shares_offered"": 51900000,
-    ""amount_raised"": 3500000000.0,
-    ""first_day_opening_price"": 146.00,
-    ""first_day_closing_price"": 144.71
+    ""offering_value"": 3500000000.0
 }";
             using var doc = JsonDocument.Parse(json);
             var ipo = FinancialDataSerializer.Instance.Deserialize<InitialPublicOffering>(doc);

--- a/src/FinancialData.Tests/Entities/InitialPublicOfferingTests.cs
+++ b/src/FinancialData.Tests/Entities/InitialPublicOfferingTests.cs
@@ -1,0 +1,33 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+using Tudormobile.FinancialData.Entities;
+using Tudormobile.FinancialData;
+
+namespace FinancialData.Tests.Entities
+{
+    [TestClass]
+    public class InitialPublicOfferingTests
+    {
+        [TestMethod]
+        public void InitialPublicOffering_Deserialize_FromJson_Works()
+        {
+            var json = @"{
+    ""trading_symbol"": ""ABNB"",
+    ""central_index_key"": ""0001559720"",
+    ""registrant_name"": ""Airbnb, Inc."",
+    ""ipo_date"": ""2020-12-10"",
+    ""offer_price"": 68.00,
+    ""shares_offered"": 51900000,
+    ""amount_raised"": 3500000000.0,
+    ""first_day_opening_price"": 146.00,
+    ""first_day_closing_price"": 144.71
+}";
+            using var doc = JsonDocument.Parse(json);
+            var ipo = FinancialDataSerializer.Instance.Deserialize<InitialPublicOffering>(doc);
+            Assert.AreEqual("ABNB", ipo.TradingSymbol);
+            Assert.AreEqual(68.00m, ipo.SharePrice);
+            Assert.AreEqual(51900000m, ipo.SharesOffered);
+            Assert.AreEqual(3500000000m, ipo.OfferingValue);
+        }
+    }
+}

--- a/src/FinancialData.Tests/Entities/InsiderTransactionTests.cs
+++ b/src/FinancialData.Tests/Entities/InsiderTransactionTests.cs
@@ -30,11 +30,19 @@ namespace FinancialData.Tests.Entities
             using var doc = JsonDocument.Parse(json);
             var insider = FinancialDataSerializer.Instance.Deserialize<InsiderTransaction>(doc);
             Assert.AreEqual("AAPL", insider.TradingSymbol);
+            Assert.AreEqual("0000320193", insider.CentralIndexKey);
+            Assert.AreEqual("Apple Inc.", insider.RegistrantName);
             Assert.AreEqual("Tim Cook", insider.InsiderName);
+            Assert.AreEqual("CEO", insider.InsiderTitle);
+            Assert.AreEqual(new DateOnly(2024, 1, 10), insider.TransactionDate);
+            Assert.AreEqual(new DateOnly(2024, 1, 12), insider.FilingDate);
             Assert.AreEqual("Sale", insider.TransactionType);
+            Assert.AreEqual("S", insider.TransactionCode);
             Assert.AreEqual(50000m, insider.Shares);
             Assert.AreEqual(185.50m, insider.Price);
             Assert.AreEqual(9275000m, insider.Value);
+            Assert.AreEqual(3200000m, insider.SharesOwnedAfterTransaction);
+            Assert.AreEqual("https://sec.gov/filing/12345", insider.SecFilingUrl);
         }
     }
 }

--- a/src/FinancialData.Tests/Entities/InsiderTransactionTests.cs
+++ b/src/FinancialData.Tests/Entities/InsiderTransactionTests.cs
@@ -1,0 +1,40 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+using Tudormobile.FinancialData.Entities;
+using Tudormobile.FinancialData;
+
+namespace FinancialData.Tests.Entities
+{
+    [TestClass]
+    public class InsiderTransactionTests
+    {
+        [TestMethod]
+        public void InsiderTransaction_Deserialize_FromJson_Works()
+        {
+            var json = @"{
+    ""trading_symbol"": ""AAPL"",
+    ""central_index_key"": ""0000320193"",
+    ""registrant_name"": ""Apple Inc."",
+    ""insider_name"": ""Tim Cook"",
+    ""insider_title"": ""CEO"",
+    ""transaction_date"": ""2024-01-10"",
+    ""filing_date"": ""2024-01-12"",
+    ""transaction_type"": ""Sale"",
+    ""transaction_code"": ""S"",
+    ""shares"": 50000,
+    ""price"": 185.50,
+    ""value"": 9275000.0,
+    ""shares_owned_after_transaction"": 3200000,
+    ""sec_filing_url"": ""https://sec.gov/filing/12345""
+}";
+            using var doc = JsonDocument.Parse(json);
+            var insider = FinancialDataSerializer.Instance.Deserialize<InsiderTransaction>(doc);
+            Assert.AreEqual("AAPL", insider.TradingSymbol);
+            Assert.AreEqual("Tim Cook", insider.InsiderName);
+            Assert.AreEqual("Sale", insider.TransactionType);
+            Assert.AreEqual(50000m, insider.Shares);
+            Assert.AreEqual(185.50m, insider.Price);
+            Assert.AreEqual(9275000m, insider.Value);
+        }
+    }
+}

--- a/src/FinancialData.Tests/Entities/InstitutionalHoldingTests.cs
+++ b/src/FinancialData.Tests/Entities/InstitutionalHoldingTests.cs
@@ -1,0 +1,39 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+using Tudormobile.FinancialData.Entities;
+using Tudormobile.FinancialData;
+
+namespace FinancialData.Tests.Entities
+{
+    [TestClass]
+    public class InstitutionalHoldingTests
+    {
+        [TestMethod]
+        public void InstitutionalHolding_Deserialize_FromJson_Works()
+        {
+            var json = @"{
+    ""trading_symbol"": ""AAPL"",
+    ""central_index_key"": ""0000320193"",
+    ""registrant_name"": ""Apple Inc."",
+    ""investor_cik"": ""0001067983"",
+    ""investor_name"": ""Berkshire Hathaway"",
+    ""period_end_date"": ""2024-03-31"",
+    ""filing_date"": ""2024-05-15"",
+    ""shares"": 915000000,
+    ""value"": 153000000000.0,
+    ""portfolio_percent"": 42.5,
+    ""shares_change"": null,
+    ""shares_change_percent"": null
+}";
+            using var doc = JsonDocument.Parse(json);
+            var holding = FinancialDataSerializer.Instance.Deserialize<InstitutionalHolding>(doc);
+            Assert.AreEqual("AAPL", holding.TradingSymbol);
+            Assert.AreEqual("Berkshire Hathaway", holding.InvestorName);
+            Assert.AreEqual(915000000m, holding.Shares);
+            Assert.AreEqual(153000000000m, holding.Value);
+            Assert.AreEqual(42.5m, holding.PortfolioPercent);
+            Assert.AreEqual(0m, holding.SharesChange);
+            Assert.AreEqual(0m, holding.SharesChangePercent);
+        }
+    }
+}

--- a/src/FinancialData.Tests/Entities/InstitutionalHoldingTests.cs
+++ b/src/FinancialData.Tests/Entities/InstitutionalHoldingTests.cs
@@ -28,7 +28,12 @@ namespace FinancialData.Tests.Entities
             using var doc = JsonDocument.Parse(json);
             var holding = FinancialDataSerializer.Instance.Deserialize<InstitutionalHolding>(doc);
             Assert.AreEqual("AAPL", holding.TradingSymbol);
+            Assert.AreEqual("0000320193", holding.CentralIndexKey);
+            Assert.AreEqual("Apple Inc.", holding.RegistrantName);
+            Assert.AreEqual("0001067983", holding.InvestorCik);
             Assert.AreEqual("Berkshire Hathaway", holding.InvestorName);
+            Assert.AreEqual(new DateOnly(2024, 3, 31), holding.PeriodEndDate);
+            Assert.AreEqual(new DateOnly(2024, 5, 15), holding.FilingDate);
             Assert.AreEqual(915000000m, holding.Shares);
             Assert.AreEqual(153000000000m, holding.Value);
             Assert.AreEqual(42.5m, holding.PortfolioPercent);

--- a/src/FinancialData.Tests/Entities/InstitutionalInvestorTests.cs
+++ b/src/FinancialData.Tests/Entities/InstitutionalInvestorTests.cs
@@ -1,0 +1,24 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+using Tudormobile.FinancialData.Entities;
+using Tudormobile.FinancialData;
+
+namespace FinancialData.Tests.Entities
+{
+    [TestClass]
+    public class InstitutionalInvestorTests
+    {
+        [TestMethod]
+        public void InstitutionalInvestor_Deserialize_FromJson_Works()
+        {
+            var json = @"{
+    ""investor_cik"": ""0001067983"",
+    ""investor_name"": ""BERKSHIRE HATHAWAY INC""
+}";
+            using var doc = JsonDocument.Parse(json);
+            var investor = FinancialDataSerializer.Instance.Deserialize<InstitutionalInvestor>(doc);
+            Assert.AreEqual("0001067983", investor.InvestorCik);
+            Assert.AreEqual("BERKSHIRE HATHAWAY INC", investor.InvestorName);
+        }
+    }
+}

--- a/src/FinancialData.Tests/Entities/InstitutionalPortfolioStatisticsTests.cs
+++ b/src/FinancialData.Tests/Entities/InstitutionalPortfolioStatisticsTests.cs
@@ -29,9 +29,16 @@ namespace FinancialData.Tests.Entities
             var stats = FinancialDataSerializer.Instance.Deserialize<InstitutionalPortfolioStatistics>(doc);
             Assert.AreEqual("0001067983", stats.InvestorCik);
             Assert.AreEqual("BERKSHIRE HATHAWAY INC", stats.InvestorName);
+            Assert.AreEqual(new DateOnly(2024, 3, 31), stats.PeriodEndDate);
+            Assert.AreEqual(new DateOnly(2024, 5, 15), stats.FilingDate);
             Assert.AreEqual(360000000000m, stats.TotalValue);
             Assert.AreEqual(45, stats.NumberOfHoldings);
             Assert.AreEqual(3, stats.NewPositions);
+            Assert.AreEqual(2, stats.SoldOutPositions);
+            Assert.AreEqual(15, stats.IncreasedPositions);
+            Assert.AreEqual(8, stats.DecreasedPositions);
+            Assert.AreEqual(5000000000m, stats.TotalValueChange);
+            Assert.AreEqual(1.41m, stats.TotalValueChangePercent);
         }
     }
 }

--- a/src/FinancialData.Tests/Entities/InstitutionalPortfolioStatisticsTests.cs
+++ b/src/FinancialData.Tests/Entities/InstitutionalPortfolioStatisticsTests.cs
@@ -1,0 +1,37 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+using Tudormobile.FinancialData.Entities;
+using Tudormobile.FinancialData;
+
+namespace FinancialData.Tests.Entities
+{
+    [TestClass]
+    public class InstitutionalPortfolioStatisticsTests
+    {
+        [TestMethod]
+        public void InstitutionalPortfolioStatistics_Deserialize_FromJson_Works()
+        {
+            var json = @"{
+    ""investor_cik"": ""0001067983"",
+    ""investor_name"": ""BERKSHIRE HATHAWAY INC"",
+    ""period_end_date"": ""2024-03-31"",
+    ""filing_date"": ""2024-05-15"",
+    ""total_value"": 360000000000.0,
+    ""number_of_holdings"": 45,
+    ""new_positions"": 3,
+    ""sold_out_positions"": 2,
+    ""increased_positions"": 15,
+    ""decreased_positions"": 8,
+    ""total_value_change"": 5000000000.0,
+    ""total_value_change_percent"": 1.41
+}";
+            using var doc = JsonDocument.Parse(json);
+            var stats = FinancialDataSerializer.Instance.Deserialize<InstitutionalPortfolioStatistics>(doc);
+            Assert.AreEqual("0001067983", stats.InvestorCik);
+            Assert.AreEqual("BERKSHIRE HATHAWAY INC", stats.InvestorName);
+            Assert.AreEqual(360000000000m, stats.TotalValue);
+            Assert.AreEqual(45, stats.NumberOfHoldings);
+            Assert.AreEqual(3, stats.NewPositions);
+        }
+    }
+}

--- a/src/FinancialData.Tests/Entities/InternationalCompanyInformationTests.cs
+++ b/src/FinancialData.Tests/Entities/InternationalCompanyInformationTests.cs
@@ -15,9 +15,7 @@ namespace FinancialData.Tests.Entities
     ""trading_symbol"": ""SHEL.L"",
     ""registrant_name"": ""Shell plc"",
     ""isin_number"": ""GB00BP6MXD84"",
-    ""lei_number"": ""21380068P1DRHMJ8KU70"",
     ""exchange"": ""LSE"",
-    ""phone_number"": ""+44 20 7934 1234"",
     ""website"": ""https://www.shell.com"",
     ""number_of_employees"": 93000
 }";
@@ -26,6 +24,8 @@ namespace FinancialData.Tests.Entities
             Assert.AreEqual("SHEL.L", info.TradingSymbol);
             Assert.AreEqual("Shell plc", info.RegistrantName);
             Assert.AreEqual("GB00BP6MXD84", info.IsinNumber);
+            Assert.AreEqual("LSE", info.Exchange);
+            Assert.AreEqual("https://www.shell.com", info.Website);
             Assert.AreEqual(93000, info.NumberOfEmployees);
         }
     }

--- a/src/FinancialData.Tests/Entities/InternationalCompanyInformationTests.cs
+++ b/src/FinancialData.Tests/Entities/InternationalCompanyInformationTests.cs
@@ -1,0 +1,32 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+using Tudormobile.FinancialData.Entities;
+using Tudormobile.FinancialData;
+
+namespace FinancialData.Tests.Entities
+{
+    [TestClass]
+    public class InternationalCompanyInformationTests
+    {
+        [TestMethod]
+        public void InternationalCompanyInformation_Deserialize_FromJson_Works()
+        {
+            var json = @"{
+    ""trading_symbol"": ""SHEL.L"",
+    ""registrant_name"": ""Shell plc"",
+    ""isin_number"": ""GB00BP6MXD84"",
+    ""lei_number"": ""21380068P1DRHMJ8KU70"",
+    ""exchange"": ""LSE"",
+    ""phone_number"": ""+44 20 7934 1234"",
+    ""website"": ""https://www.shell.com"",
+    ""number_of_employees"": 93000
+}";
+            using var doc = JsonDocument.Parse(json);
+            var info = FinancialDataSerializer.Instance.Deserialize<InternationalCompanyInformation>(doc);
+            Assert.AreEqual("SHEL.L", info.TradingSymbol);
+            Assert.AreEqual("Shell plc", info.RegistrantName);
+            Assert.AreEqual("GB00BP6MXD84", info.IsinNumber);
+            Assert.AreEqual(93000, info.NumberOfEmployees);
+        }
+    }
+}

--- a/src/FinancialData.Tests/Entities/InternationalStockPriceTests.cs
+++ b/src/FinancialData.Tests/Entities/InternationalStockPriceTests.cs
@@ -1,0 +1,33 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+using Tudormobile.FinancialData.Entities;
+using Tudormobile.FinancialData;
+
+namespace FinancialData.Tests.Entities
+{
+    [TestClass]
+    public class InternationalStockPriceTests
+    {
+        [TestMethod]
+        public void InternationalStockPrice_Deserialize_FromJson_Works()
+        {
+            var json = @"{
+    ""trading_symbol"": ""SHEL.L"",
+    ""date"": ""2024-01-15"",
+    ""currency_code"": ""GBP"",
+    ""open"": 2450.50,
+    ""high"": 2475.00,
+    ""low"": 2445.00,
+    ""close"": 2470.00,
+    ""volume"": 5000000
+}";
+            using var doc = JsonDocument.Parse(json);
+            var price = FinancialDataSerializer.Instance.Deserialize<InternationalStockPrice>(doc);
+            Assert.AreEqual("SHEL.L", price.TradingSymbol);
+            Assert.AreEqual(2450.50m, price.Open);
+            Assert.AreEqual(2475.00m, price.High);
+            Assert.AreEqual(2445.00m, price.Low);
+            Assert.AreEqual(2470.00m, price.Close);
+        }
+    }
+}

--- a/src/FinancialData.Tests/Entities/InvestmentAdviserInformationTests.cs
+++ b/src/FinancialData.Tests/Entities/InvestmentAdviserInformationTests.cs
@@ -1,0 +1,37 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+using Tudormobile.FinancialData.Entities;
+using Tudormobile.FinancialData;
+
+namespace FinancialData.Tests.Entities
+{
+    [TestClass]
+    public class InvestmentAdviserInformationTests
+    {
+        [TestMethod]
+        public void InvestmentAdviserInformation_Deserialize_FromJson_Works()
+        {
+            var json = @"{
+    ""crd_number"": ""107665"",
+    ""sec_file_number"": ""801-10746"",
+    ""firm_name"": ""BlackRock, Inc."",
+    ""filing_date"": ""2024-01-15"",
+    ""assets_under_management"": 10000000000000.0,
+    ""number_of_employees"": 19800,
+    ""number_of_clients"": 2500,
+    ""high_net_worth_clients"": 150,
+    ""is_registered_investment_company"": true,
+    ""is_private_fund"": false
+}";
+            using var doc = JsonDocument.Parse(json);
+            var adviser = FinancialDataSerializer.Instance.Deserialize<InvestmentAdviserInformation>(doc);
+            Assert.AreEqual("107665", adviser.CrdNumber);
+            Assert.AreEqual("BlackRock, Inc.", adviser.FirmName);
+            Assert.AreEqual(10000000000000m, adviser.AssetsUnderManagement);
+            Assert.AreEqual(19800, adviser.NumberOfEmployees);
+            Assert.AreEqual(2500, adviser.NumberOfClients);
+            Assert.IsTrue(adviser.IsRegisteredInvestmentCompany);
+            Assert.IsFalse(adviser.IsPrivateFund);
+        }
+    }
+}

--- a/src/FinancialData.Tests/Entities/InvestmentAdviserNameTests.cs
+++ b/src/FinancialData.Tests/Entities/InvestmentAdviserNameTests.cs
@@ -1,0 +1,26 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+using Tudormobile.FinancialData.Entities;
+using Tudormobile.FinancialData;
+
+namespace FinancialData.Tests.Entities
+{
+    [TestClass]
+    public class InvestmentAdviserNameTests
+    {
+        [TestMethod]
+        public void InvestmentAdviserName_Deserialize_FromJson_Works()
+        {
+            var json = @"{
+    ""crd_number"": ""107665"",
+    ""sec_file_number"": ""801-10746"",
+    ""firm_name"": ""BlackRock, Inc.""
+}";
+            using var doc = JsonDocument.Parse(json);
+            var adviserName = FinancialDataSerializer.Instance.Deserialize<InvestmentAdviserName>(doc);
+            Assert.AreEqual("107665", adviserName.CrdNumber);
+            Assert.AreEqual("801-10746", adviserName.SecFileNumber);
+            Assert.AreEqual("BlackRock, Inc.", adviserName.FirmName);
+        }
+    }
+}

--- a/src/FinancialData.Tests/Entities/IpoCalendarTests.cs
+++ b/src/FinancialData.Tests/Entities/IpoCalendarTests.cs
@@ -1,0 +1,25 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+using Tudormobile.FinancialData.Entities;
+using Tudormobile.FinancialData;
+
+namespace FinancialData.Tests.Entities
+{
+    [TestClass]
+    public class IpoCalendarTests
+    {
+        [TestMethod]
+        public void IpoCalendar_Deserialize_FromJson_Works()
+        {
+            var json = @"{
+    ""trading_symbol"": ""RDDT"",
+    ""central_index_key"": ""0001713445"",
+    ""registrant_name"": ""Reddit, Inc."",
+    ""ipo_date"": ""2024-03-21""
+}";
+            using var doc = JsonDocument.Parse(json);
+            var calendar = FinancialDataSerializer.Instance.Deserialize<IpoCalendar>(doc);
+            Assert.AreEqual("RDDT", calendar.TradingSymbol);
+        }
+    }
+}

--- a/src/FinancialData.Tests/Entities/KeyMetricsTests.cs
+++ b/src/FinancialData.Tests/Entities/KeyMetricsTests.cs
@@ -31,9 +31,19 @@ namespace FinancialData.Tests.Entities
             using var doc = JsonDocument.Parse(json);
             var keyMetrics = FinancialDataSerializer.Instance.Deserialize<KeyMetrics>(doc);
             Assert.AreEqual("AAPL", keyMetrics.TradingSymbol);
+            Assert.AreEqual("0000320193", keyMetrics.CentralIndexKey);
+            Assert.AreEqual("Apple Inc.", keyMetrics.RegistrantName);
+            Assert.AreEqual("2024", keyMetrics.FiscalYear);
+            Assert.AreEqual(new DateOnly(2024, 9, 30), keyMetrics.PeriodEndDate);
             Assert.AreEqual(6.42m, keyMetrics.EarningsPerShare);
+            Assert.AreEqual(6.50m, keyMetrics.EarningsPerShareForecast);
             Assert.AreEqual(28.5m, keyMetrics.PriceToEarningsRatio);
+            Assert.AreEqual(27.8m, keyMetrics.ForwardPriceToEarningsRatio);
+            Assert.AreEqual(45.2m, keyMetrics.PriceToBookRatio);
+            Assert.AreEqual(131000000000m, keyMetrics.Ebitda);
             Assert.AreEqual(99000000000m, keyMetrics.FreeCashFlow);
+            Assert.AreEqual(0.625m, keyMetrics.ReturnOnEquity);
+            Assert.AreEqual(1.25m, keyMetrics.OneYearBeta);
             Assert.AreEqual(0m, keyMetrics.DebtToEquityRatio);
         }
     }

--- a/src/FinancialData.Tests/Entities/KeyMetricsTests.cs
+++ b/src/FinancialData.Tests/Entities/KeyMetricsTests.cs
@@ -1,0 +1,40 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+using Tudormobile.FinancialData.Entities;
+using Tudormobile.FinancialData;
+
+namespace FinancialData.Tests.Entities
+{
+    [TestClass]
+    public class KeyMetricsTests
+    {
+        [TestMethod]
+        public void KeyMetrics_Deserialize_FromJson_Works()
+        {
+            var json = @"{
+    ""trading_symbol"": ""AAPL"",
+    ""central_index_key"": ""0000320193"",
+    ""registrant_name"": ""Apple Inc."",
+    ""fiscal_year"": ""2024"",
+    ""period_end_date"": ""2024-09-30"",
+    ""earnings_per_share"": 6.42,
+    ""earnings_per_share_forecast"": 6.50,
+    ""price_to_earnings_ratio"": 28.5,
+    ""forward_price_to_earnings_ratio"": 27.8,
+    ""price_to_book_ratio"": 45.2,
+    ""ebitda"": 131000000000.0,
+    ""free_cash_flow"": 99000000000.0,
+    ""return_on_equity"": 0.625,
+    ""one_year_beta"": 1.25,
+    ""debt_to_equity_ratio"": null
+}";
+            using var doc = JsonDocument.Parse(json);
+            var keyMetrics = FinancialDataSerializer.Instance.Deserialize<KeyMetrics>(doc);
+            Assert.AreEqual("AAPL", keyMetrics.TradingSymbol);
+            Assert.AreEqual(6.42m, keyMetrics.EarningsPerShare);
+            Assert.AreEqual(28.5m, keyMetrics.PriceToEarningsRatio);
+            Assert.AreEqual(99000000000m, keyMetrics.FreeCashFlow);
+            Assert.AreEqual(0m, keyMetrics.DebtToEquityRatio);
+        }
+    }
+}

--- a/src/FinancialData.Tests/Entities/LatestPriceTests.cs
+++ b/src/FinancialData.Tests/Entities/LatestPriceTests.cs
@@ -1,0 +1,32 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+using Tudormobile.FinancialData.Entities;
+using Tudormobile.FinancialData;
+
+namespace FinancialData.Tests.Entities
+{
+    [TestClass]
+    public class LatestPriceTests
+    {
+        [TestMethod]
+        public void LatestPrice_Deserialize_FromJson_Works()
+        {
+            var json = @"{
+    ""trading_symbol"": ""TSLA"",
+    ""time"": ""2024-01-15 15:45:00"",
+    ""open"": 245.30,
+    ""high"": 246.80,
+    ""low"": 244.90,
+    ""close"": 246.50,
+    ""volume"": 85000
+}";
+            using var doc = JsonDocument.Parse(json);
+            var latestPrice = FinancialDataSerializer.Instance.Deserialize<LatestPrice>(doc);
+            Assert.AreEqual("TSLA", latestPrice.TradingSymbol);
+            Assert.AreEqual(245.30m, latestPrice.Open);
+            Assert.AreEqual(246.80m, latestPrice.High);
+            Assert.AreEqual(244.90m, latestPrice.Low);
+            Assert.AreEqual(246.50m, latestPrice.Close);
+        }
+    }
+}

--- a/src/FinancialData.Tests/Entities/MarketCapTests.cs
+++ b/src/FinancialData.Tests/Entities/MarketCapTests.cs
@@ -1,0 +1,28 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+using Tudormobile.FinancialData.Entities;
+using Tudormobile.FinancialData;
+
+namespace FinancialData.Tests.Entities
+{
+    [TestClass]
+    public class MarketCapTests
+    {
+        [TestMethod]
+        public void MarketCap_Deserialize_FromJson_Works()
+        {
+            var json = @"{
+    ""trading_symbol"": ""MSFT"",
+    ""central_index_key"": ""0000789019"",
+    ""registrant_name"": ""MICROSOFT CORP"",
+    ""date"": ""2024-01-15"",
+    ""market_cap"": 3100000000000.0
+}";
+            using var doc = JsonDocument.Parse(json);
+            var marketCap = FinancialDataSerializer.Instance.Deserialize<MarketCap>(doc);
+            Assert.AreEqual("MSFT", marketCap.TradingSymbol);
+            Assert.AreEqual("0000789019", marketCap.CentralIndexKey);
+            Assert.AreEqual(3100000000000m, marketCap.MarketCapValue);
+        }
+    }
+}

--- a/src/FinancialData.Tests/Entities/MarketCapTests.cs
+++ b/src/FinancialData.Tests/Entities/MarketCapTests.cs
@@ -15,8 +15,13 @@ namespace FinancialData.Tests.Entities
     ""trading_symbol"": ""MSFT"",
     ""central_index_key"": ""0000789019"",
     ""registrant_name"": ""MICROSOFT CORP"",
-    ""date"": ""2024-01-15"",
-    ""market_cap"": 3100000000000.0
+    ""fiscal_year"": ""2024"",
+    ""market_cap_value"": 3100000000000.0,
+    ""change_in_market_cap"": 50000000000.0,
+    ""percentage_change_in_market_cap"": 1.64,
+    ""shares_outstanding"": 7430000000.0,
+    ""change_in_shares_outstanding"": 0.0,
+    ""percentage_change_in_shares_outstanding"": 0.0
 }";
             using var doc = JsonDocument.Parse(json);
             var marketCap = FinancialDataSerializer.Instance.Deserialize<MarketCap>(doc);

--- a/src/FinancialData.Tests/Entities/MinutePriceTests.cs
+++ b/src/FinancialData.Tests/Entities/MinutePriceTests.cs
@@ -1,0 +1,53 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+using Tudormobile.FinancialData.Entities;
+using Tudormobile.FinancialData;
+
+namespace FinancialData.Tests.Entities
+{
+    [TestClass]
+    public class MinutePriceTests
+    {
+        [TestMethod]
+        public void MinutePrice_Deserialize_FromJson_Works()
+        {
+            var json = @"{
+    ""trading_symbol"": ""AAPL"",
+    ""time"": ""2024-01-15 14:30:00"",
+    ""open"": 185.50,
+    ""high"": 185.75,
+    ""low"": 185.40,
+    ""close"": 185.65,
+    ""volume"": 125000
+}";
+            using var doc = JsonDocument.Parse(json);
+            var minutePrice = FinancialDataSerializer.Instance.Deserialize<MinutePrice>(doc);
+            Assert.AreEqual("AAPL", minutePrice.TradingSymbol);
+            Assert.AreEqual(185.50m, minutePrice.Open);
+            Assert.AreEqual(185.75m, minutePrice.High);
+            Assert.AreEqual(185.40m, minutePrice.Low);
+            Assert.AreEqual(185.65m, minutePrice.Close);
+            Assert.AreEqual(125000m, minutePrice.Volume);
+        }
+
+        [TestMethod]
+        public void MinutePrice_Deserialize_HandlesNullDecimals()
+        {
+            var json = @"{
+    ""trading_symbol"": ""AAPL"",
+    ""time"": ""2024-01-15 14:30:00"",
+    ""open"": null,
+    ""high"": 185.75,
+    ""low"": null,
+    ""close"": 185.65,
+    ""volume"": null
+}";
+            using var doc = JsonDocument.Parse(json);
+            var minutePrice = FinancialDataSerializer.Instance.Deserialize<MinutePrice>(doc);
+            Assert.AreEqual("AAPL", minutePrice.TradingSymbol);
+            Assert.AreEqual(0m, minutePrice.Open);
+            Assert.AreEqual(0m, minutePrice.Low);
+            Assert.AreEqual(0m, minutePrice.Volume);
+        }
+    }
+}

--- a/src/FinancialData.Tests/Entities/MutualFundHoldingsTests.cs
+++ b/src/FinancialData.Tests/Entities/MutualFundHoldingsTests.cs
@@ -1,0 +1,52 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+using Tudormobile.FinancialData.Entities;
+using Tudormobile.FinancialData;
+
+namespace FinancialData.Tests.Entities
+{
+    [TestClass]
+    public class MutualFundHoldingsTests
+    {
+        [TestMethod]
+        public void MutualFundHoldings_Deserialize_FromJson_Works()
+        {
+            var json = @"{
+    ""central_index_key"": ""0000036405"",
+    ""registrant_name"": ""VANGUARD INDEX FUNDS"",
+    ""period_of_report"": ""2025-06-30"",
+    ""fund_name"": ""Admiral Shares"",
+    ""fund_symbol"": ""VTSAX"",
+    ""series_id"": ""S000002848"",
+    ""class_id"": ""C000007806"",
+    ""issuer_name"": ""Frequency Electronics Inc"",
+    ""lei_number"": ""549300S56SO2JB5JBE31"",
+    ""title_of_security"": ""FREQUENCY ELECT"",
+    ""trading_symbol"": ""FEIM"",
+    ""cusip_number"": ""358010106"",
+    ""isin_number"": ""US3580101067"",
+    ""amount_of_units"": 228179,
+    ""description_of_units"": ""NS"",
+    ""denomination_currency"": ""USD"",
+    ""value_in_usd"": 5181945.09,
+    ""percentage_value_compared_to_assets"": 0.000271384232,
+    ""payoff_profile"": ""Long"",
+    ""asset_type"": ""EC"",
+    ""issuer_type"": ""CORP"",
+    ""country_of_issuer_or_investment"": ""US"",
+    ""is_restricted_security"": false,
+    ""fair_value_level"": 1,
+    ""is_cash_collateral"": false,
+    ""is_non_cash_collateral"": false,
+    ""is_loan_by_fund"": true
+}";
+            using var doc = JsonDocument.Parse(json);
+            var mutualFundHoldings = FinancialDataSerializer.Instance.Deserialize<MutualFundHoldings>(doc);
+            Assert.AreEqual("0000036405", mutualFundHoldings.CentralIndexKey);
+            Assert.AreEqual("VTSAX", mutualFundHoldings.FundSymbol);
+            Assert.AreEqual("FEIM", mutualFundHoldings.TradingSymbol);
+            Assert.AreEqual(5181945.09m, mutualFundHoldings.ValueInUsd);
+            Assert.AreEqual(true, mutualFundHoldings.IsLoanByFund);
+        }
+    }
+}

--- a/src/FinancialData.Tests/Entities/MutualFundStatisticsTests.cs
+++ b/src/FinancialData.Tests/Entities/MutualFundStatisticsTests.cs
@@ -1,0 +1,50 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+using Tudormobile.FinancialData.Entities;
+using Tudormobile.FinancialData;
+
+namespace FinancialData.Tests.Entities
+{
+    [TestClass]
+    public class MutualFundStatisticsTests
+    {
+        [TestMethod]
+        public void MutualFundStatistics_Deserialize_FromJson_Works()
+        {
+            var json = @"{
+    ""central_index_key"": ""0000036405"",
+    ""registrant_name"": ""VANGUARD INDEX FUNDS"",
+    ""period_of_report"": ""2025-06-30"",
+    ""fund_name"": ""Admiral Shares"",
+    ""fund_symbol"": ""VTSAX"",
+    ""series_id"": ""S000002848"",
+    ""class_id"": ""C000007806"",
+    ""total_assets"": 1915212703487.01,
+    ""total_liabilities"": 5763123365.99,
+    ""net_assets"": 1909449580121.02,
+    ""return_preceding_month1"": -0.6729,
+    ""return_preceding_month2"": 6.3455,
+    ""return_preceding_month3"": 5.07574,
+    ""realized_gain_preceding_month1"": 983065935.64,
+    ""change_in_unrealized_appreciation_preceding_month1"": -11394591977.19,
+    ""realized_gain_preceding_month2"": 287029511.93,
+    ""change_in_unrealized_appreciation_preceding_month2"": 105734824564.66,
+    ""realized_gain_preceding_month3"": 2243886605.76,
+    ""change_in_unrealized_appreciation_preceding_month3"": 87596494350.2,
+    ""share_sale_preceding_month1"": 30533447572.6504,
+    ""share_redemption_preceding_month1"": 9354960674.63,
+    ""share_sale_preceding_month2"": 9024030148.45996,
+    ""share_redemption_preceding_month2"": 9833704993.95,
+    ""share_sale_preceding_month3"": 12681244786.0796,
+    ""share_redemption_preceding_month3"": 12999259996.1
+}";
+            using var doc = JsonDocument.Parse(json);
+            var mutualFundStatistics = FinancialDataSerializer.Instance.Deserialize<MutualFundStatistics>(doc);
+            Assert.AreEqual("0000036405", mutualFundStatistics.CentralIndexKey);
+            Assert.AreEqual("VTSAX", mutualFundStatistics.FundSymbol);
+            Assert.AreEqual(1915212703487.01m, mutualFundStatistics.TotalAssets);
+            Assert.AreEqual(1909449580121.02m, mutualFundStatistics.NetAssets);
+            Assert.AreEqual(-0.6729m, mutualFundStatistics.ReturnPrecedingMonth1);
+        }
+    }
+}

--- a/src/FinancialData.Tests/Entities/MutualFundSymbolTests.cs
+++ b/src/FinancialData.Tests/Entities/MutualFundSymbolTests.cs
@@ -1,0 +1,24 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+using Tudormobile.FinancialData.Entities;
+using Tudormobile.FinancialData;
+
+namespace FinancialData.Tests.Entities
+{
+    [TestClass]
+    public class MutualFundSymbolTests
+    {
+        [TestMethod]
+        public void MutualFundSymbol_Deserialize_FromJson_Works()
+        {
+            var json = @"{
+    ""trading_symbol"": ""AAAAX"",
+    ""fund_name"": ""DWS RREEF Real Assets Fund, Class A""
+}";
+            using var doc = JsonDocument.Parse(json);
+            var mutualFundSymbol = FinancialDataSerializer.Instance.Deserialize<MutualFundSymbol>(doc);
+            Assert.AreEqual("AAAAX", mutualFundSymbol.TradingSymbol);
+            Assert.AreEqual("DWS RREEF Real Assets Fund, Class A", mutualFundSymbol.FundName);
+        }
+    }
+}

--- a/src/FinancialData.Tests/Entities/OptionChainTests.cs
+++ b/src/FinancialData.Tests/Entities/OptionChainTests.cs
@@ -1,0 +1,31 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+using Tudormobile.FinancialData.Entities;
+using Tudormobile.FinancialData;
+
+namespace FinancialData.Tests.Entities
+{
+    [TestClass]
+    public class OptionChainTests
+    {
+        [TestMethod]
+        public void OptionChain_Deserialize_FromJson_Works()
+        {
+            var json = @"{
+    ""trading_symbol"": ""AAPL"",
+    ""central_index_key"": ""0000320193"",
+    ""registrant_name"": ""Apple Inc."",
+    ""contract_name"": ""AAPL240119C00180000"",
+    ""expiration_date"": ""2024-01-19"",
+    ""put_or_call"": ""Call"",
+    ""strike_price"": 180.00
+}";
+            using var doc = JsonDocument.Parse(json);
+            var optionChain = FinancialDataSerializer.Instance.Deserialize<OptionChain>(doc);
+            Assert.AreEqual("AAPL", optionChain.TradingSymbol);
+            Assert.AreEqual("AAPL240119C00180000", optionChain.ContractName);
+            Assert.AreEqual("Call", optionChain.PutOrCall);
+            Assert.AreEqual(180.00m, optionChain.StrikePrice);
+        }
+    }
+}

--- a/src/FinancialData.Tests/Entities/OptionChainTests.cs
+++ b/src/FinancialData.Tests/Entities/OptionChainTests.cs
@@ -23,7 +23,10 @@ namespace FinancialData.Tests.Entities
             using var doc = JsonDocument.Parse(json);
             var optionChain = FinancialDataSerializer.Instance.Deserialize<OptionChain>(doc);
             Assert.AreEqual("AAPL", optionChain.TradingSymbol);
+            Assert.AreEqual("0000320193", optionChain.CentralIndexKey);
+            Assert.AreEqual("Apple Inc.", optionChain.RegistrantName);
             Assert.AreEqual("AAPL240119C00180000", optionChain.ContractName);
+            Assert.AreEqual(new DateOnly(2024, 1, 19), optionChain.ExpirationDate);
             Assert.AreEqual("Call", optionChain.PutOrCall);
             Assert.AreEqual(180.00m, optionChain.StrikePrice);
         }

--- a/src/FinancialData.Tests/Entities/OptionGreeksTests.cs
+++ b/src/FinancialData.Tests/Entities/OptionGreeksTests.cs
@@ -1,0 +1,32 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+using Tudormobile.FinancialData.Entities;
+using Tudormobile.FinancialData;
+
+namespace FinancialData.Tests.Entities
+{
+    [TestClass]
+    public class OptionGreeksTests
+    {
+        [TestMethod]
+        public void OptionGreeks_Deserialize_FromJson_Works()
+        {
+            var json = @"{
+    ""contract_name"": ""AAPL240119C00180000"",
+    ""date"": ""2024-01-15"",
+    ""delta"": 0.65,
+    ""gamma"": 0.025,
+    ""theta"": -0.08,
+    ""vega"": 0.15,
+    ""rho"": 0.05
+}";
+            using var doc = JsonDocument.Parse(json);
+            var greeks = FinancialDataSerializer.Instance.Deserialize<OptionGreeks>(doc);
+            Assert.AreEqual("AAPL240119C00180000", greeks.ContractName);
+            Assert.AreEqual(0.65m, greeks.Delta);
+            Assert.AreEqual(0.025m, greeks.Gamma);
+            Assert.AreEqual(-0.08m, greeks.Theta);
+            Assert.AreEqual(0.15m, greeks.Vega);
+        }
+    }
+}

--- a/src/FinancialData.Tests/Entities/OptionGreeksTests.cs
+++ b/src/FinancialData.Tests/Entities/OptionGreeksTests.cs
@@ -23,10 +23,12 @@ namespace FinancialData.Tests.Entities
             using var doc = JsonDocument.Parse(json);
             var greeks = FinancialDataSerializer.Instance.Deserialize<OptionGreeks>(doc);
             Assert.AreEqual("AAPL240119C00180000", greeks.ContractName);
+            Assert.AreEqual(new DateOnly(2024, 1, 15), greeks.Date);
             Assert.AreEqual(0.65m, greeks.Delta);
             Assert.AreEqual(0.025m, greeks.Gamma);
             Assert.AreEqual(-0.08m, greeks.Theta);
             Assert.AreEqual(0.15m, greeks.Vega);
+            Assert.AreEqual(0.05m, greeks.Rho);
         }
     }
 }

--- a/src/FinancialData.Tests/Entities/OptionPriceTests.cs
+++ b/src/FinancialData.Tests/Entities/OptionPriceTests.cs
@@ -1,0 +1,31 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+using Tudormobile.FinancialData.Entities;
+using Tudormobile.FinancialData;
+
+namespace FinancialData.Tests.Entities
+{
+    [TestClass]
+    public class OptionPriceTests
+    {
+        [TestMethod]
+        public void OptionPrice_Deserialize_FromJson_Works()
+        {
+            var json = @"{
+    ""contract_name"": ""AAPL240119C00180000"",
+    ""date"": ""2024-01-15"",
+    ""open"": 8.50,
+    ""high"": 9.20,
+    ""low"": 8.30,
+    ""close"": 9.00,
+    ""volume"": 5000
+}";
+            using var doc = JsonDocument.Parse(json);
+            var optionPrice = FinancialDataSerializer.Instance.Deserialize<OptionPrice>(doc);
+            Assert.AreEqual("AAPL240119C00180000", optionPrice.ContractName);
+            Assert.AreEqual(8.50m, optionPrice.Open);
+            Assert.AreEqual(9.20m, optionPrice.High);
+            Assert.AreEqual(9.00m, optionPrice.Close);
+        }
+    }
+}

--- a/src/FinancialData.Tests/Entities/PressReleaseTests.cs
+++ b/src/FinancialData.Tests/Entities/PressReleaseTests.cs
@@ -1,0 +1,30 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+using Tudormobile.FinancialData.Entities;
+using Tudormobile.FinancialData;
+
+namespace FinancialData.Tests.Entities
+{
+    [TestClass]
+    public class PressReleaseTests
+    {
+        [TestMethod]
+        public void PressRelease_Deserialize_FromJson_Works()
+        {
+            var json = @"{
+    ""trading_symbol"": ""TSLA"",
+    ""central_index_key"": ""0001318605"",
+    ""registrant_name"": ""Tesla, Inc."",
+    ""date_time"": ""2024-01-24 16:30:00"",
+    ""headline"": ""Tesla Reports Q4 2023 Results"",
+    ""text"": ""Tesla announced fourth quarter results..."",
+    ""url"": ""https://ir.tesla.com/press-release/""
+}";
+            using var doc = JsonDocument.Parse(json);
+            var pressRelease = FinancialDataSerializer.Instance.Deserialize<PressRelease>(doc);
+            Assert.AreEqual("TSLA", pressRelease.TradingSymbol);
+            Assert.AreEqual("0001318605", pressRelease.CentralIndexKey);
+            Assert.AreEqual("Tesla Reports Q4 2023 Results", pressRelease.Headline);
+        }
+    }
+}

--- a/src/FinancialData.Tests/Entities/PressReleaseTests.cs
+++ b/src/FinancialData.Tests/Entities/PressReleaseTests.cs
@@ -24,7 +24,11 @@ namespace FinancialData.Tests.Entities
             var pressRelease = FinancialDataSerializer.Instance.Deserialize<PressRelease>(doc);
             Assert.AreEqual("TSLA", pressRelease.TradingSymbol);
             Assert.AreEqual("0001318605", pressRelease.CentralIndexKey);
+            Assert.AreEqual("Tesla, Inc.", pressRelease.RegistrantName);
+            Assert.AreEqual(new DateTime(2024, 1, 24, 16, 30, 0), pressRelease.DateTime);
             Assert.AreEqual("Tesla Reports Q4 2023 Results", pressRelease.Headline);
+            Assert.AreEqual("Tesla announced fourth quarter results...", pressRelease.Text);
+            Assert.AreEqual("https://ir.tesla.com/press-release/", pressRelease.Url);
         }
     }
 }

--- a/src/FinancialData.Tests/Entities/ProposedSaleTests.cs
+++ b/src/FinancialData.Tests/Entities/ProposedSaleTests.cs
@@ -1,0 +1,30 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+using Tudormobile.FinancialData.Entities;
+using Tudormobile.FinancialData;
+
+namespace FinancialData.Tests.Entities
+{
+    [TestClass]
+    public class ProposedSaleTests
+    {
+        [TestMethod]
+        public void ProposedSale_Deserialize_FromJson_Works()
+        {
+            var json = @"{
+    ""trading_symbol"": ""AMZN"",
+    ""central_index_key"": ""0001018724"",
+    ""registrant_name"": ""AMAZON COM INC"",
+    ""insider_name"": ""Jeffrey P. Bezos"",
+    ""filing_date"": ""2024-02-02"",
+    ""shares"": 50000000,
+    ""sec_filing_url"": ""https://www.sec.gov/cgi-bin/browse-edgar""
+}";
+            using var doc = JsonDocument.Parse(json);
+            var proposedSale = FinancialDataSerializer.Instance.Deserialize<ProposedSale>(doc);
+            Assert.AreEqual("AMZN", proposedSale.TradingSymbol);
+            Assert.AreEqual("Jeffrey P. Bezos", proposedSale.InsiderName);
+            Assert.AreEqual(50000000m, proposedSale.Shares);
+        }
+    }
+}

--- a/src/FinancialData.Tests/Entities/ProposedSaleTests.cs
+++ b/src/FinancialData.Tests/Entities/ProposedSaleTests.cs
@@ -23,8 +23,12 @@ namespace FinancialData.Tests.Entities
             using var doc = JsonDocument.Parse(json);
             var proposedSale = FinancialDataSerializer.Instance.Deserialize<ProposedSale>(doc);
             Assert.AreEqual("AMZN", proposedSale.TradingSymbol);
+            Assert.AreEqual("0001018724", proposedSale.CentralIndexKey);
+            Assert.AreEqual("AMAZON COM INC", proposedSale.RegistrantName);
             Assert.AreEqual("Jeffrey P. Bezos", proposedSale.InsiderName);
+            Assert.AreEqual(new DateOnly(2024, 2, 2), proposedSale.FilingDate);
             Assert.AreEqual(50000000m, proposedSale.Shares);
+            Assert.AreEqual("https://www.sec.gov/cgi-bin/browse-edgar", proposedSale.SecFilingUrl);
         }
     }
 }

--- a/src/FinancialData.Tests/Entities/SecPressReleaseTests.cs
+++ b/src/FinancialData.Tests/Entities/SecPressReleaseTests.cs
@@ -1,0 +1,26 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+using Tudormobile.FinancialData.Entities;
+using Tudormobile.FinancialData;
+
+namespace FinancialData.Tests.Entities
+{
+    [TestClass]
+    public class SecPressReleaseTests
+    {
+        [TestMethod]
+        public void SecPressRelease_Deserialize_FromJson_Works()
+        {
+            var json = @"{
+    ""date_time"": ""2024-01-15 12:00:00"",
+    ""headline"": ""SEC Charges Company with Accounting Fraud"",
+    ""text"": ""The Securities and Exchange Commission today announced..."",
+    ""url"": ""https://www.sec.gov/news/press-release/""
+}";
+            using var doc = JsonDocument.Parse(json);
+            var secPressRelease = FinancialDataSerializer.Instance.Deserialize<SecPressRelease>(doc);
+            Assert.AreEqual("SEC Charges Company with Accounting Fraud", secPressRelease.Headline);
+            Assert.AreEqual("https://www.sec.gov/news/press-release/", secPressRelease.Url);
+        }
+    }
+}

--- a/src/FinancialData.Tests/Entities/SecPressReleaseTests.cs
+++ b/src/FinancialData.Tests/Entities/SecPressReleaseTests.cs
@@ -19,7 +19,9 @@ namespace FinancialData.Tests.Entities
 }";
             using var doc = JsonDocument.Parse(json);
             var secPressRelease = FinancialDataSerializer.Instance.Deserialize<SecPressRelease>(doc);
+            Assert.AreEqual(new DateTime(2024, 1, 15, 12, 0, 0), secPressRelease.DateTime);
             Assert.AreEqual("SEC Charges Company with Accounting Fraud", secPressRelease.Headline);
+            Assert.AreEqual("The Securities and Exchange Commission today announced...", secPressRelease.Text);
             Assert.AreEqual("https://www.sec.gov/news/press-release/", secPressRelease.Url);
         }
     }

--- a/src/FinancialData.Tests/Entities/SecuritiesInformationTests.cs
+++ b/src/FinancialData.Tests/Entities/SecuritiesInformationTests.cs
@@ -22,6 +22,10 @@ namespace FinancialData.Tests.Entities
             using var doc = JsonDocument.Parse(json);
             var securities = FinancialDataSerializer.Instance.Deserialize<SecuritiesInformation>(doc);
             Assert.AreEqual("IBM", securities.TradingSymbol);
+            Assert.AreEqual("INTERNATIONAL BUSINESS MACHINES CORP", securities.IssuerName);
+            Assert.AreEqual("459200101", securities.CusipNumber);
+            Assert.AreEqual("US4592001014", securities.IsinNumber);
+            Assert.AreEqual("BBG000BLNNH6", securities.FigiIdentifier);
             Assert.AreEqual("Common Stock", securities.SecurityType);
         }
     }

--- a/src/FinancialData.Tests/Entities/SecuritiesInformationTests.cs
+++ b/src/FinancialData.Tests/Entities/SecuritiesInformationTests.cs
@@ -1,0 +1,28 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+using Tudormobile.FinancialData.Entities;
+using Tudormobile.FinancialData;
+
+namespace FinancialData.Tests.Entities
+{
+    [TestClass]
+    public class SecuritiesInformationTests
+    {
+        [TestMethod]
+        public void SecuritiesInformation_Deserialize_FromJson_Works()
+        {
+            var json = @"{
+    ""trading_symbol"": ""IBM"",
+    ""issuer_name"": ""INTERNATIONAL BUSINESS MACHINES CORP"",
+    ""cusip_number"": ""459200101"",
+    ""isin_number"": ""US4592001014"",
+    ""figi_identifier"": ""BBG000BLNNH6"",
+    ""security_type"": ""Common Stock""
+}";
+            using var doc = JsonDocument.Parse(json);
+            var securities = FinancialDataSerializer.Instance.Deserialize<SecuritiesInformation>(doc);
+            Assert.AreEqual("IBM", securities.TradingSymbol);
+            Assert.AreEqual("Common Stock", securities.SecurityType);
+        }
+    }
+}

--- a/src/FinancialData.Tests/Entities/SenateTradingTests.cs
+++ b/src/FinancialData.Tests/Entities/SenateTradingTests.cs
@@ -1,0 +1,31 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+using Tudormobile.FinancialData.Entities;
+using Tudormobile.FinancialData;
+
+namespace FinancialData.Tests.Entities
+{
+    [TestClass]
+    public class SenateTradingTests
+    {
+        [TestMethod]
+        public void SenateTrading_Deserialize_FromJson_Works()
+        {
+            var json = @"{
+    ""trading_symbol"": ""NVDA"",
+    ""senator_name"": ""John Doe"",
+    ""transaction_date"": ""2024-01-10"",
+    ""disclosure_date"": ""2024-01-25"",
+    ""transaction_type"": ""Purchase"",
+    ""asset_type"": ""Stock"",
+    ""amount_range"": ""$15,001 - $50,000"",
+    ""comment"": """"
+}";
+            using var doc = JsonDocument.Parse(json);
+            var senateTrading = FinancialDataSerializer.Instance.Deserialize<SenateTrading>(doc);
+            Assert.AreEqual("NVDA", senateTrading.TradingSymbol);
+            Assert.AreEqual("John Doe", senateTrading.SenatorName);
+            Assert.AreEqual("Purchase", senateTrading.TransactionType);
+        }
+    }
+}

--- a/src/FinancialData.Tests/Entities/SenateTradingTests.cs
+++ b/src/FinancialData.Tests/Entities/SenateTradingTests.cs
@@ -25,7 +25,12 @@ namespace FinancialData.Tests.Entities
             var senateTrading = FinancialDataSerializer.Instance.Deserialize<SenateTrading>(doc);
             Assert.AreEqual("NVDA", senateTrading.TradingSymbol);
             Assert.AreEqual("John Doe", senateTrading.SenatorName);
+            Assert.AreEqual(new DateOnly(2024, 1, 10), senateTrading.TransactionDate);
+            Assert.AreEqual(new DateOnly(2024, 1, 25), senateTrading.DisclosureDate);
             Assert.AreEqual("Purchase", senateTrading.TransactionType);
+            Assert.AreEqual("Stock", senateTrading.AssetType);
+            Assert.AreEqual("$15,001 - $50,000", senateTrading.AmountRange);
+            Assert.AreEqual("", senateTrading.Comment);
         }
     }
 }

--- a/src/FinancialData.Tests/Entities/ShortInterestTests.cs
+++ b/src/FinancialData.Tests/Entities/ShortInterestTests.cs
@@ -1,0 +1,32 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+using Tudormobile.FinancialData.Entities;
+using Tudormobile.FinancialData;
+
+namespace FinancialData.Tests.Entities
+{
+    [TestClass]
+    public class ShortInterestTests
+    {
+        [TestMethod]
+        public void ShortInterest_Deserialize_FromJson_Works()
+        {
+            var json = @"{
+    ""trading_symbol"": ""GME"",
+    ""central_index_key"": ""0001326380"",
+    ""registrant_name"": ""GAMESTOP CORP"",
+    ""settlement_date"": ""2024-01-15"",
+    ""short_interest"": 45000000,
+    ""average_daily_volume"": 8500000,
+    ""days_to_cover"": 5.29,
+    ""percent_of_float"": 15.5
+}";
+            using var doc = JsonDocument.Parse(json);
+            var shortInterest = FinancialDataSerializer.Instance.Deserialize<ShortInterest>(doc);
+            Assert.AreEqual("GME", shortInterest.TradingSymbol);
+            Assert.AreEqual(45000000m, shortInterest.ShortedSecurities);
+            Assert.AreEqual(8500000m, shortInterest.AverageDailyVolume);
+            Assert.AreEqual(5.29m, shortInterest.DaysToCover);
+        }
+    }
+}

--- a/src/FinancialData.Tests/Entities/ShortInterestTests.cs
+++ b/src/FinancialData.Tests/Entities/ShortInterestTests.cs
@@ -13,13 +13,16 @@ namespace FinancialData.Tests.Entities
         {
             var json = @"{
     ""trading_symbol"": ""GME"",
-    ""central_index_key"": ""0001326380"",
-    ""registrant_name"": ""GAMESTOP CORP"",
+    ""title_of_security"": ""GAMESTOP CORP"",
+    ""market_code"": ""NYSE"",
     ""settlement_date"": ""2024-01-15"",
-    ""short_interest"": 45000000,
+    ""shorted_securities"": 45000000,
+    ""previous_shorted_securities"": 50000000,
+    ""change_in_shorted_securities"": -5000000,
+    ""percentage_change_in_shorted_securities"": -10.0,
     ""average_daily_volume"": 8500000,
     ""days_to_cover"": 5.29,
-    ""percent_of_float"": 15.5
+    ""is_stock_split"": false
 }";
             using var doc = JsonDocument.Parse(json);
             var shortInterest = FinancialDataSerializer.Instance.Deserialize<ShortInterest>(doc);

--- a/src/FinancialData.Tests/Entities/SplitsCalendarTests.cs
+++ b/src/FinancialData.Tests/Entities/SplitsCalendarTests.cs
@@ -1,0 +1,25 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+using Tudormobile.FinancialData.Entities;
+using Tudormobile.FinancialData;
+
+namespace FinancialData.Tests.Entities
+{
+    [TestClass]
+    public class SplitsCalendarTests
+    {
+        [TestMethod]
+        public void SplitsCalendar_Deserialize_FromJson_Works()
+        {
+            var json = @"{
+    ""trading_symbol"": ""NVDA"",
+    ""central_index_key"": ""0001045810"",
+    ""registrant_name"": ""NVIDIA CORP"",
+    ""execution_date"": ""2024-06-10""
+}";
+            using var doc = JsonDocument.Parse(json);
+            var calendar = FinancialDataSerializer.Instance.Deserialize<SplitsCalendar>(doc);
+            Assert.AreEqual("NVDA", calendar.TradingSymbol);
+        }
+    }
+}

--- a/src/FinancialData.Tests/Entities/StockPriceTests.cs
+++ b/src/FinancialData.Tests/Entities/StockPriceTests.cs
@@ -7,7 +7,7 @@ namespace FinancialData.Tests.Entities
     public class StockPriceTests
     {
         [TestMethod]
-        public void StockPrice_Deserialize_FromJson_Works()
+        public void StockPrice_Deserialize_FromJson_WithDate_Works()
         {
             var json = @"{
     ""trading_symbol"": ""MSFT"",
@@ -27,6 +27,120 @@ namespace FinancialData.Tests.Entities
             Assert.AreEqual(432.63m, stockPrice.Low);
             Assert.AreEqual(437.42m, stockPrice.Close);
             Assert.AreEqual(26009430.0m, stockPrice.Volume);
+        }
+
+        [TestMethod]
+        public void StockPrice_Deserialize_FromJson_WithTime_Works()
+        {
+            var json = @"{
+    ""trading_symbol"": ""AAPL"",
+    ""time"": ""2024-12-04T14:30:00-05:00"",
+    ""open"": 195.50,
+    ""high"": 196.20,
+    ""low"": 195.10,
+    ""close"": 196.00,
+    ""volume"": 45000000.0
+}";
+            using var doc = JsonDocument.Parse(json);
+            var stockPrice = FinancialDataSerializer.Instance.Deserialize<StockPrice>(doc);
+            Assert.AreEqual("AAPL", stockPrice.TradingSymbol);
+            Assert.AreEqual(new DateTimeOffset(2024, 12, 4, 14, 30, 0, TimeSpan.FromHours(-5)), stockPrice.Time);
+            Assert.AreEqual(195.50m, stockPrice.Open);
+            Assert.AreEqual(196.20m, stockPrice.High);
+            Assert.AreEqual(195.10m, stockPrice.Low);
+            Assert.AreEqual(196.00m, stockPrice.Close);
+            Assert.AreEqual(45000000.0m, stockPrice.Volume);
+        }
+
+        [TestMethod]
+        public void StockPrice_WithDate_CanAccessTime()
+        {
+            var json = @"{
+    ""trading_symbol"": ""GOOGL"",
+    ""date"": ""2024-12-04"",
+    ""open"": 140.50,
+    ""high"": 142.00,
+    ""low"": 140.00,
+    ""close"": 141.50,
+    ""volume"": 30000000.0
+}";
+            using var doc = JsonDocument.Parse(json);
+            var stockPrice = FinancialDataSerializer.Instance.Deserialize<StockPrice>(doc);
+
+            // Verify Date is set correctly
+            Assert.AreEqual(new DateOnly(2024, 12, 4), stockPrice.Date);
+
+            // Verify Time is derived from Date (midnight in local time zone)
+            var expectedDate = new DateOnly(2024, 12, 4);
+            var expectedTime = expectedDate.ToDateTime(TimeOnly.MinValue);
+            Assert.AreEqual(expectedTime, stockPrice.Time.DateTime);
+            Assert.AreEqual(expectedDate, DateOnly.FromDateTime(stockPrice.Time.Date));
+        }
+
+        [TestMethod]
+        public void StockPrice_WithTime_CanAccessDate()
+        {
+            var json = @"{
+    ""trading_symbol"": ""TSLA"",
+    ""time"": ""2024-12-04T16:00:00Z"",
+    ""open"": 250.00,
+    ""high"": 255.00,
+    ""low"": 248.00,
+    ""close"": 253.50,
+    ""volume"": 60000000.0
+}";
+            using var doc = JsonDocument.Parse(json);
+            var stockPrice = FinancialDataSerializer.Instance.Deserialize<StockPrice>(doc);
+
+            // Verify Time is set correctly
+            Assert.AreEqual(new DateTimeOffset(2024, 12, 4, 16, 0, 0, TimeSpan.Zero), stockPrice.Time);
+
+            // Verify Date is derived from Time
+            Assert.AreEqual(new DateOnly(2024, 12, 4), stockPrice.Date);
+        }
+
+        [TestMethod]
+        public void StockPrice_WithBothDateAndTime_BothAccessible()
+        {
+            // If both date and time are provided in JSON, both should be accessible
+            var json = @"{
+    ""trading_symbol"": ""NVDA"",
+    ""date"": ""2024-12-04"",
+    ""time"": ""2024-12-05T10:30:00Z"",
+    ""open"": 500.00,
+    ""high"": 510.00,
+    ""low"": 495.00,
+    ""close"": 505.00,
+    ""volume"": 40000000.0
+}";
+            using var doc = JsonDocument.Parse(json);
+            var stockPrice = FinancialDataSerializer.Instance.Deserialize<StockPrice>(doc);
+
+            // When both are set, the order in JSON determines which is set last
+            // In this case, "date" comes before "time" in the JSON, so "time" would be set last
+            // However, the actual behavior depends on which field is deserialized last
+            // Let's just verify both are accessible and one of them is properly set
+            Assert.IsTrue(stockPrice.Date != default || stockPrice.Time != default);
+        }
+
+        [TestMethod]
+        public void StockPrice_EmptyObject_HasDefaultValues()
+        {
+            var json = @"{
+    ""trading_symbol"": ""TEST"",
+    ""open"": 100.00,
+    ""high"": 105.00,
+    ""low"": 99.00,
+    ""close"": 102.00,
+    ""volume"": 1000000.0
+}";
+            using var doc = JsonDocument.Parse(json);
+            var stockPrice = FinancialDataSerializer.Instance.Deserialize<StockPrice>(doc);
+
+            // When neither date nor time is provided, defaults should be returned
+            Assert.AreEqual(default(DateOnly), stockPrice.Date);
+            // Note: DateTimeOffset default includes the local time zone offset
+            Assert.AreEqual(default(DateTime), stockPrice.Time.DateTime);
         }
     }
 }

--- a/src/FinancialData.Tests/Entities/StockPriceTests.cs
+++ b/src/FinancialData.Tests/Entities/StockPriceTests.cs
@@ -116,10 +116,8 @@ namespace FinancialData.Tests.Entities
             using var doc = JsonDocument.Parse(json);
             var stockPrice = FinancialDataSerializer.Instance.Deserialize<StockPrice>(doc);
 
-            // When both are set, the order in JSON determines which is set last
-            // In this case, "date" comes before "time" in the JSON, so "time" would be set last
-            // However, the actual behavior depends on which field is deserialized last
-            // Let's just verify both are accessible and one of them is properly set
+            // In the API definition, both "date" and "time" will never be set, therefore we
+            // just verify both are accessible and one of them is properly set
             Assert.IsTrue(stockPrice.Date != default || stockPrice.Time != default);
         }
 

--- a/src/FinancialData.Tests/Entities/StockSplitTests.cs
+++ b/src/FinancialData.Tests/Entities/StockSplitTests.cs
@@ -1,0 +1,26 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text.Json;
+using Tudormobile.FinancialData.Entities;
+using Tudormobile.FinancialData;
+
+namespace FinancialData.Tests.Entities
+{
+    [TestClass]
+    public class StockSplitTests
+    {
+        [TestMethod]
+        public void StockSplit_Deserialize_FromJson_Works()
+        {
+            var json = @"{
+    ""trading_symbol"": ""TSLA"",
+    ""central_index_key"": ""0001318605"",
+    ""registrant_name"": ""Tesla, Inc."",
+    ""execution_date"": ""2022-08-25"",
+    ""split_ratio"": ""3:1""
+}";
+            using var doc = JsonDocument.Parse(json);
+            var split = FinancialDataSerializer.Instance.Deserialize<StockSplit>(doc);
+            Assert.AreEqual("TSLA", split.TradingSymbol);
+        }
+    }
+}

--- a/src/FinancialData/ApiEndpoints/IFinancialDataClient.BasicInformation.cs
+++ b/src/FinancialData/ApiEndpoints/IFinancialDataClient.BasicInformation.cs
@@ -1,8 +1,42 @@
-﻿namespace Tudormobile.FinancialData;
+﻿using Tudormobile.FinancialData.Entities;
 
+namespace Tudormobile.FinancialData;
+
+/// <summary>
+/// Provides methods for retrieving basic company information from the FinancialData API.
+/// </summary>
 public partial interface IFinancialDataClient
 {
-    // Supress warnings to document unsupported api endpoints.
+    // Suppress warnings to document unsupported api endpoints.
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
-#pragma warning restore CS1591 // Missing XML comment for publicly visible type or members
+
+    // Company Information - Standard Subscription
+    Task<FinancialDataResponse<List<CompanyInformation>>> GetCompanyInformationAsync(string identifier, CancellationToken cancellationToken = default)
+        => FinancialDataResponse<List<CompanyInformation>>.StandardSubscriptionNotImplemented();
+
+    // International Company Information - Premium Subscription
+    Task<FinancialDataResponse<List<InternationalCompanyInformation>>> GetInternationalCompanyInformationAsync(string identifier, CancellationToken cancellationToken = default)
+        => FinancialDataResponse<List<InternationalCompanyInformation>>.PremiumSubscriptionNotImplemented();
+
+    // Key Metrics - Standard Subscription
+    Task<FinancialDataResponse<List<KeyMetrics>>> GetKeyMetricsAsync(string identifier, CancellationToken cancellationToken = default)
+        => FinancialDataResponse<List<KeyMetrics>>.StandardSubscriptionNotImplemented();
+
+    // Market Cap - Standard Subscription
+    Task<FinancialDataResponse<List<MarketCap>>> GetMarketCapAsync(string identifier, int offset = 0, CancellationToken cancellationToken = default)
+        => FinancialDataResponse<List<MarketCap>>.StandardSubscriptionNotImplemented();
+
+    // Employee Count - Standard Subscription
+    Task<FinancialDataResponse<List<EmployeeCount>>> GetEmployeeCountAsync(string identifier, CancellationToken cancellationToken = default)
+        => FinancialDataResponse<List<EmployeeCount>>.StandardSubscriptionNotImplemented();
+
+    // Executive Compensation - Premium Subscription
+    Task<FinancialDataResponse<List<ExecutiveCompensation>>> GetExecutiveCompensationAsync(string identifier, CancellationToken cancellationToken = default)
+        => FinancialDataResponse<List<ExecutiveCompensation>>.PremiumSubscriptionNotImplemented();
+
+    // Securities Information - Standard Subscription
+    Task<FinancialDataResponse<List<SecuritiesInformation>>> GetSecuritiesInformationAsync(string identifier, CancellationToken cancellationToken = default)
+        => FinancialDataResponse<List<SecuritiesInformation>>.StandardSubscriptionNotImplemented();
+
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 }

--- a/src/FinancialData/ApiEndpoints/IFinancialDataClient.CryptoCurrencies.cs
+++ b/src/FinancialData/ApiEndpoints/IFinancialDataClient.CryptoCurrencies.cs
@@ -1,8 +1,34 @@
-﻿namespace Tudormobile.FinancialData;
+﻿using Tudormobile.FinancialData.Entities;
 
+namespace Tudormobile.FinancialData;
+
+/// <summary>
+/// Provides methods for retrieving cryptocurrency data from the FinancialData API.
+/// </summary>
 public partial interface IFinancialDataClient
 {
-    // Supress warnings to document unsupported api endpoints.
+    // Suppress warnings to document unsupported api endpoints.
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
-#pragma warning restore CS1591 // Missing XML comment for publicly visible type or members
+
+    // Crypto Symbols - Premium Subscription
+    Task<FinancialDataResponse<List<CryptoSymbol>>> GetCryptoSymbolsAsync(int offset = 0, CancellationToken cancellationToken = default)
+        => FinancialDataResponse<List<CryptoSymbol>>.PremiumSubscriptionNotImplemented();
+
+    // Crypto Information - Premium Subscription
+    Task<FinancialDataResponse<List<CryptoInformation>>> GetCryptoInformationAsync(string identifier, CancellationToken cancellationToken = default)
+        => FinancialDataResponse<List<CryptoInformation>>.PremiumSubscriptionNotImplemented();
+
+    // Crypto Quotes - Premium Subscription
+    Task<FinancialDataResponse<List<CryptoQuote>>> GetCryptoQuotesAsync(IEnumerable<string> identifiers, CancellationToken cancellationToken = default)
+        => FinancialDataResponse<List<CryptoQuote>>.PremiumSubscriptionNotImplemented();
+
+    // Crypto Prices - Premium Subscription
+    Task<FinancialDataResponse<List<CryptoPrice>>> GetCryptoPricesAsync(string identifier, int offset = 0, CancellationToken cancellationToken = default)
+        => FinancialDataResponse<List<CryptoPrice>>.PremiumSubscriptionNotImplemented();
+
+    // Crypto Minute Prices - Premium Subscription
+    Task<FinancialDataResponse<List<CryptoMinutePrice>>> GetCryptoMinutePricesAsync(string identifier, DateOnly date, int offset = 0, CancellationToken cancellationToken = default)
+        => FinancialDataResponse<List<CryptoMinutePrice>>.PremiumSubscriptionNotImplemented();
+
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 }

--- a/src/FinancialData/ApiEndpoints/IFinancialDataClient.DerivitiesData.cs
+++ b/src/FinancialData/ApiEndpoints/IFinancialDataClient.DerivitiesData.cs
@@ -1,8 +1,34 @@
-﻿namespace Tudormobile.FinancialData;
+﻿using Tudormobile.FinancialData.Entities;
 
+namespace Tudormobile.FinancialData;
+
+/// <summary>
+/// Provides methods for retrieving derivatives data (options and futures) from the FinancialData API.
+/// </summary>
 public partial interface IFinancialDataClient
 {
-    // Supress warnings to document unsupported api endpoints.
+    // Suppress warnings to document unsupported api endpoints.
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
-#pragma warning restore CS1591 // Missing XML comment for publicly visible type or members
+
+    // Option Chain - Premium Subscription
+    Task<FinancialDataResponse<List<OptionChain>>> GetOptionChainAsync(string identifier, DateOnly? expirationDate = null, CancellationToken cancellationToken = default)
+        => FinancialDataResponse<List<OptionChain>>.PremiumSubscriptionNotImplemented();
+
+    // Option Prices - Premium Subscription
+    Task<FinancialDataResponse<List<OptionPrice>>> GetOptionPricesAsync(string contractName, int offset = 0, CancellationToken cancellationToken = default)
+        => FinancialDataResponse<List<OptionPrice>>.PremiumSubscriptionNotImplemented();
+
+    // Option Greeks - Premium Subscription
+    Task<FinancialDataResponse<List<OptionGreeks>>> GetOptionGreeksAsync(string contractName, int offset = 0, CancellationToken cancellationToken = default)
+        => FinancialDataResponse<List<OptionGreeks>>.PremiumSubscriptionNotImplemented();
+
+    // Futures Symbols - Premium Subscription
+    Task<FinancialDataResponse<List<FuturesSymbol>>> GetFuturesSymbolsAsync(int offset = 0, CancellationToken cancellationToken = default)
+        => FinancialDataResponse<List<FuturesSymbol>>.PremiumSubscriptionNotImplemented();
+
+    // Futures Prices - Premium Subscription
+    Task<FinancialDataResponse<List<FuturesPrice>>> GetFuturesPricesAsync(string identifier, int offset = 0, CancellationToken cancellationToken = default)
+        => FinancialDataResponse<List<FuturesPrice>>.PremiumSubscriptionNotImplemented();
+
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 }

--- a/src/FinancialData/ApiEndpoints/IFinancialDataClient.EsgData.cs
+++ b/src/FinancialData/ApiEndpoints/IFinancialDataClient.EsgData.cs
@@ -1,8 +1,26 @@
-﻿namespace Tudormobile.FinancialData;
+﻿using Tudormobile.FinancialData.Entities;
 
+namespace Tudormobile.FinancialData;
+
+/// <summary>
+/// Provides methods for retrieving ESG (Environmental, Social, Governance) data from the FinancialData API.
+/// </summary>
 public partial interface IFinancialDataClient
 {
-    // Supress warnings to document unsupported api endpoints.
+    // Suppress warnings to document unsupported api endpoints.
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
-#pragma warning restore CS1591 // Missing XML comment for publicly visible type or members
+
+    // ESG Scores - Premium Subscription
+    Task<FinancialDataResponse<List<EsgScore>>> GetEsgScoresAsync(string identifier, int offset = 0, CancellationToken cancellationToken = default)
+        => FinancialDataResponse<List<EsgScore>>.PremiumSubscriptionNotImplemented();
+
+    // ESG Ratings - Premium Subscription
+    Task<FinancialDataResponse<List<EsgRating>>> GetEsgRatingsAsync(string identifier, int offset = 0, CancellationToken cancellationToken = default)
+        => FinancialDataResponse<List<EsgRating>>.PremiumSubscriptionNotImplemented();
+
+    // Industry ESG Scores - Premium Subscription
+    Task<FinancialDataResponse<List<IndustryEsgScore>>> GetIndustryEsgScoresAsync(string industry, int offset = 0, CancellationToken cancellationToken = default)
+        => FinancialDataResponse<List<IndustryEsgScore>>.PremiumSubscriptionNotImplemented();
+
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 }

--- a/src/FinancialData/ApiEndpoints/IFinancialDataClient.EtfData.cs
+++ b/src/FinancialData/ApiEndpoints/IFinancialDataClient.EtfData.cs
@@ -1,8 +1,16 @@
-﻿namespace Tudormobile.FinancialData;
+﻿using Tudormobile.FinancialData.Entities;
+
+namespace Tudormobile.FinancialData;
 
 public partial interface IFinancialDataClient
 {
     // Supress warnings to document unsupported api endpoints.
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+    Task<FinancialDataResponse<List<EtfQuotes>>> GetEtfQuotesAsync(string identifier, int offset = 0, CancellationToken cancellationToken = default)
+        => FinancialDataResponse<List<EtfQuotes>>.PremiumSubscriptionNotImplemented();
+    Task<FinancialDataResponse<List<EtfPrices>>> GetEtfPricesAsync(string identifier, int offset = 0, CancellationToken cancellationToken = default)
+        => FinancialDataResponse<List<EtfPrices>>.PremiumSubscriptionNotImplemented();
+    Task<FinancialDataResponse<List<EtfHoldings>>> GetEtfHoldingsAsync(int offset = 0, CancellationToken cancellationToken = default)
+        => FinancialDataResponse<List<EtfHoldings>>.PremiumSubscriptionNotImplemented();
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or members
 }

--- a/src/FinancialData/ApiEndpoints/IFinancialDataClient.EventCalendars.cs
+++ b/src/FinancialData/ApiEndpoints/IFinancialDataClient.EventCalendars.cs
@@ -1,8 +1,34 @@
-﻿namespace Tudormobile.FinancialData;
+﻿using Tudormobile.FinancialData.Entities;
 
+namespace Tudormobile.FinancialData;
+
+/// <summary>
+/// Provides methods for retrieving event calendar data from the FinancialData API.
+/// </summary>
 public partial interface IFinancialDataClient
 {
-    // Supress warnings to document unsupported api endpoints.
+    // Suppress warnings to document unsupported api endpoints.
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
-#pragma warning restore CS1591 // Missing XML comment for publicly visible type or members
+
+    // Earnings Calendar - Standard Subscription
+    Task<FinancialDataResponse<List<EarningsCalendar>>> GetEarningsCalendarAsync(DateOnly? date = null, int offset = 0, CancellationToken cancellationToken = default)
+        => FinancialDataResponse<List<EarningsCalendar>>.StandardSubscriptionNotImplemented();
+
+    // IPO Calendar - Standard Subscription
+    Task<FinancialDataResponse<List<IpoCalendar>>> GetIpoCalendarAsync(DateOnly? date = null, int offset = 0, CancellationToken cancellationToken = default)
+        => FinancialDataResponse<List<IpoCalendar>>.StandardSubscriptionNotImplemented();
+
+    // Splits Calendar - Standard Subscription
+    Task<FinancialDataResponse<List<SplitsCalendar>>> GetSplitsCalendarAsync(DateOnly? date = null, int offset = 0, CancellationToken cancellationToken = default)
+        => FinancialDataResponse<List<SplitsCalendar>>.StandardSubscriptionNotImplemented();
+
+    // Dividends Calendar - Standard Subscription
+    Task<FinancialDataResponse<List<DividendsCalendar>>> GetDividendsCalendarAsync(DateOnly? date = null, int offset = 0, CancellationToken cancellationToken = default)
+        => FinancialDataResponse<List<DividendsCalendar>>.StandardSubscriptionNotImplemented();
+
+    // Economic Calendar - Premium Subscription
+    Task<FinancialDataResponse<List<EconomicCalendar>>> GetEconomicCalendarAsync(string? country = null, int offset = 0, CancellationToken cancellationToken = default)
+        => FinancialDataResponse<List<EconomicCalendar>>.PremiumSubscriptionNotImplemented();
+
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 }

--- a/src/FinancialData/ApiEndpoints/IFinancialDataClient.ForexData.cs
+++ b/src/FinancialData/ApiEndpoints/IFinancialDataClient.ForexData.cs
@@ -1,8 +1,30 @@
-﻿namespace Tudormobile.FinancialData;
+﻿using Tudormobile.FinancialData.Entities;
 
+namespace Tudormobile.FinancialData;
+
+/// <summary>
+/// Provides methods for retrieving forex (foreign exchange) data from the FinancialData API.
+/// </summary>
 public partial interface IFinancialDataClient
 {
-    // Supress warnings to document unsupported api endpoints.
+    // Suppress warnings to document unsupported api endpoints.
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
-#pragma warning restore CS1591 // Missing XML comment for publicly visible type or members
+
+    // Forex Symbols - Premium Subscription
+    Task<FinancialDataResponse<List<ForexSymbol>>> GetForexSymbolsAsync(int offset = 0, CancellationToken cancellationToken = default)
+        => FinancialDataResponse<List<ForexSymbol>>.PremiumSubscriptionNotImplemented();
+
+    // Forex Quotes - Premium Subscription
+    Task<FinancialDataResponse<List<ForexQuote>>> GetForexQuotesAsync(IEnumerable<string> identifiers, CancellationToken cancellationToken = default)
+        => FinancialDataResponse<List<ForexQuote>>.PremiumSubscriptionNotImplemented();
+
+    // Forex Prices - Premium Subscription
+    Task<FinancialDataResponse<List<ForexPrice>>> GetForexPricesAsync(string identifier, int offset = 0, CancellationToken cancellationToken = default)
+        => FinancialDataResponse<List<ForexPrice>>.PremiumSubscriptionNotImplemented();
+
+    // Forex Minute Prices - Premium Subscription
+    Task<FinancialDataResponse<List<ForexMinutePrice>>> GetForexMinutePricesAsync(string identifier, DateOnly date, int offset = 0, CancellationToken cancellationToken = default)
+        => FinancialDataResponse<List<ForexMinutePrice>>.PremiumSubscriptionNotImplemented();
+
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 }

--- a/src/FinancialData/ApiEndpoints/IFinancialDataClient.InsiderTrading.cs
+++ b/src/FinancialData/ApiEndpoints/IFinancialDataClient.InsiderTrading.cs
@@ -1,8 +1,30 @@
-﻿namespace Tudormobile.FinancialData;
+﻿using Tudormobile.FinancialData.Entities;
 
+namespace Tudormobile.FinancialData;
+
+/// <summary>
+/// Provides methods for retrieving insider trading data from the FinancialData API.
+/// </summary>
 public partial interface IFinancialDataClient
 {
-    // Supress warnings to document unsupported api endpoints.
+    // Suppress warnings to document unsupported api endpoints.
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
-#pragma warning restore CS1591 // Missing XML comment for publicly visible type or members
+
+    // Insider Transactions - Premium Subscription
+    Task<FinancialDataResponse<List<InsiderTransaction>>> GetInsiderTransactionsAsync(string identifier, int offset = 0, CancellationToken cancellationToken = default)
+        => FinancialDataResponse<List<InsiderTransaction>>.PremiumSubscriptionNotImplemented();
+
+    // Proposed Sales (Form 144) - Premium Subscription
+    Task<FinancialDataResponse<List<ProposedSale>>> GetProposedSalesAsync(string identifier, int offset = 0, CancellationToken cancellationToken = default)
+        => FinancialDataResponse<List<ProposedSale>>.PremiumSubscriptionNotImplemented();
+
+    // Senate Trading - Premium Subscription
+    Task<FinancialDataResponse<List<SenateTrading>>> GetSenateTradingAsync(string? identifier = null, int offset = 0, CancellationToken cancellationToken = default)
+        => FinancialDataResponse<List<SenateTrading>>.PremiumSubscriptionNotImplemented();
+
+    // House Trading - Premium Subscription
+    Task<FinancialDataResponse<List<HouseTrading>>> GetHouseTradingAsync(string? identifier = null, int offset = 0, CancellationToken cancellationToken = default)
+        => FinancialDataResponse<List<HouseTrading>>.PremiumSubscriptionNotImplemented();
+
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 }

--- a/src/FinancialData/ApiEndpoints/IFinancialDataClient.InstitutionalTrading.cs
+++ b/src/FinancialData/ApiEndpoints/IFinancialDataClient.InstitutionalTrading.cs
@@ -1,8 +1,26 @@
-﻿namespace Tudormobile.FinancialData;
+﻿using Tudormobile.FinancialData.Entities;
 
+namespace Tudormobile.FinancialData;
+
+/// <summary>
+/// Provides methods for retrieving institutional trading and holdings data from the FinancialData API.
+/// </summary>
 public partial interface IFinancialDataClient
 {
-    // Supress warnings to document unsupported api endpoints.
+    // Suppress warnings to document unsupported api endpoints.
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
-#pragma warning restore CS1591 // Missing XML comment for publicly visible type or members
+
+    // Institutional Investors - Premium Subscription
+    Task<FinancialDataResponse<List<InstitutionalInvestor>>> GetInstitutionalInvestorsAsync(int offset = 0, CancellationToken cancellationToken = default)
+        => FinancialDataResponse<List<InstitutionalInvestor>>.PremiumSubscriptionNotImplemented();
+
+    // Institutional Holdings - Premium Subscription
+    Task<FinancialDataResponse<List<InstitutionalHolding>>> GetInstitutionalHoldingsAsync(string identifier, int offset = 0, CancellationToken cancellationToken = default)
+        => FinancialDataResponse<List<InstitutionalHolding>>.PremiumSubscriptionNotImplemented();
+
+    // Institutional Portfolio Statistics - Premium Subscription
+    Task<FinancialDataResponse<List<InstitutionalPortfolioStatistics>>> GetInstitutionalPortfolioStatisticsAsync(string investorCik, int offset = 0, CancellationToken cancellationToken = default)
+        => FinancialDataResponse<List<InstitutionalPortfolioStatistics>>.PremiumSubscriptionNotImplemented();
+
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 }

--- a/src/FinancialData/ApiEndpoints/IFinancialDataClient.InvestmentAdvisers.cs
+++ b/src/FinancialData/ApiEndpoints/IFinancialDataClient.InvestmentAdvisers.cs
@@ -1,8 +1,22 @@
-﻿namespace Tudormobile.FinancialData;
+﻿using Tudormobile.FinancialData.Entities;
 
+namespace Tudormobile.FinancialData;
+
+/// <summary>
+/// Provides methods for retrieving investment adviser data from the FinancialData API.
+/// </summary>
 public partial interface IFinancialDataClient
 {
-    // Supress warnings to document unsupported api endpoints.
+    // Suppress warnings to document unsupported api endpoints.
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
-#pragma warning restore CS1591 // Missing XML comment for publicly visible type or members
+
+    // Investment Adviser Names - Premium Subscription
+    Task<FinancialDataResponse<List<InvestmentAdviserName>>> GetInvestmentAdviserNamesAsync(int offset = 0, CancellationToken cancellationToken = default)
+        => FinancialDataResponse<List<InvestmentAdviserName>>.PremiumSubscriptionNotImplemented();
+
+    // Investment Adviser Information - Premium Subscription
+    Task<FinancialDataResponse<List<InvestmentAdviserInformation>>> GetInvestmentAdviserInformationAsync(string crdNumber, CancellationToken cancellationToken = default)
+        => FinancialDataResponse<List<InvestmentAdviserInformation>>.PremiumSubscriptionNotImplemented();
+
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 }

--- a/src/FinancialData/ApiEndpoints/IFinancialDataClient.MarketIndexes.cs
+++ b/src/FinancialData/ApiEndpoints/IFinancialDataClient.MarketIndexes.cs
@@ -1,8 +1,18 @@
-﻿namespace Tudormobile.FinancialData;
+﻿using Tudormobile.FinancialData.Entities;
+
+namespace Tudormobile.FinancialData;
 
 public partial interface IFinancialDataClient
 {
     // Supress warnings to document unsupported api endpoints.
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+    Task<FinancialDataResponse<List<IndexSymbol>>> GetIndexSymbolsAsync(CancellationToken cancellationToken = default)
+        => FinancialDataResponse<List<IndexSymbol>>.StandardSubscriptionNotImplemented();
+    Task<FinancialDataResponse<List<IndexQuote>>> GetIndexQuotesAsync(IEnumerable<string> identifiers, CancellationToken cancellationToken = default)
+        => FinancialDataResponse<List<IndexQuote>>.PremiumSubscriptionNotImplemented();
+    Task<FinancialDataResponse<List<IndexPrice>>> GetIndexPricesAsync(string identifier, int offset = 0, CancellationToken cancellationToken = default)
+        => FinancialDataResponse<List<IndexPrice>>.StandardSubscriptionNotImplemented();
+    Task<FinancialDataResponse<List<IndexConstituent>>> GetIndexConstituentsAsync(string identifier, int offset = 0, CancellationToken cancellationToken = default)
+        => FinancialDataResponse<List<IndexConstituent>>.StandardSubscriptionNotImplemented();
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or members
 }

--- a/src/FinancialData/ApiEndpoints/IFinancialDataClient.MarketNews.cs
+++ b/src/FinancialData/ApiEndpoints/IFinancialDataClient.MarketNews.cs
@@ -1,8 +1,26 @@
-﻿namespace Tudormobile.FinancialData;
+﻿using Tudormobile.FinancialData.Entities;
 
+namespace Tudormobile.FinancialData;
+
+/// <summary>
+/// Provides methods for retrieving market news and press releases from the FinancialData API.
+/// </summary>
 public partial interface IFinancialDataClient
 {
-    // Supress warnings to document unsupported api endpoints.
+    // Suppress warnings to document unsupported api endpoints.
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
-#pragma warning restore CS1591 // Missing XML comment for publicly visible type or members
+
+    // Press Releases - Premium Subscription
+    Task<FinancialDataResponse<List<PressRelease>>> GetPressReleasesAsync(string identifier, int offset = 0, CancellationToken cancellationToken = default)
+        => FinancialDataResponse<List<PressRelease>>.PremiumSubscriptionNotImplemented();
+
+    // SEC Press Releases - Premium Subscription
+    Task<FinancialDataResponse<List<SecPressRelease>>> GetSecPressReleasesAsync(int offset = 0, CancellationToken cancellationToken = default)
+        => FinancialDataResponse<List<SecPressRelease>>.PremiumSubscriptionNotImplemented();
+
+    // Fed Press Releases - Premium Subscription
+    Task<FinancialDataResponse<List<FedPressRelease>>> GetFedPressReleasesAsync(int offset = 0, CancellationToken cancellationToken = default)
+        => FinancialDataResponse<List<FedPressRelease>>.PremiumSubscriptionNotImplemented();
+
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 }

--- a/src/FinancialData/ApiEndpoints/IFinancialDataClient.MiscellaneousData.cs
+++ b/src/FinancialData/ApiEndpoints/IFinancialDataClient.MiscellaneousData.cs
@@ -1,8 +1,34 @@
-﻿namespace Tudormobile.FinancialData;
+﻿using Tudormobile.FinancialData.Entities;
 
+namespace Tudormobile.FinancialData;
+
+/// <summary>
+/// Provides methods for retrieving miscellaneous financial data from the FinancialData API.
+/// </summary>
 public partial interface IFinancialDataClient
 {
-    // Supress warnings to document unsupported api endpoints.
+    // Suppress warnings to document unsupported api endpoints.
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
-#pragma warning restore CS1591 // Missing XML comment for publicly visible type or members
+
+    // Earnings Releases - Standard Subscription
+    Task<FinancialDataResponse<List<EarningsRelease>>> GetEarningsReleasesAsync(string identifier, int offset = 0, CancellationToken cancellationToken = default)
+        => FinancialDataResponse<List<EarningsRelease>>.StandardSubscriptionNotImplemented();
+
+    // Initial Public Offerings - Standard Subscription
+    Task<FinancialDataResponse<List<InitialPublicOffering>>> GetInitialPublicOfferingsAsync(int offset = 0, CancellationToken cancellationToken = default)
+        => FinancialDataResponse<List<InitialPublicOffering>>.StandardSubscriptionNotImplemented();
+
+    // Stock Splits - Standard Subscription
+    Task<FinancialDataResponse<List<StockSplit>>> GetStockSplitsAsync(string identifier, int offset = 0, CancellationToken cancellationToken = default)
+        => FinancialDataResponse<List<StockSplit>>.StandardSubscriptionNotImplemented();
+
+    // Dividends - Standard Subscription
+    Task<FinancialDataResponse<List<Dividend>>> GetDividendsAsync(string identifier, int offset = 0, CancellationToken cancellationToken = default)
+        => FinancialDataResponse<List<Dividend>>.StandardSubscriptionNotImplemented();
+
+    // Short Interest - Premium Subscription
+    Task<FinancialDataResponse<List<ShortInterest>>> GetShortInterestAsync(string identifier, int offset = 0, CancellationToken cancellationToken = default)
+        => FinancialDataResponse<List<ShortInterest>>.PremiumSubscriptionNotImplemented();
+
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 }

--- a/src/FinancialData/ApiEndpoints/IFinancialDataClient.MutualFunds.cs
+++ b/src/FinancialData/ApiEndpoints/IFinancialDataClient.MutualFunds.cs
@@ -1,8 +1,16 @@
-﻿namespace Tudormobile.FinancialData;
+﻿using Tudormobile.FinancialData.Entities;
+
+namespace Tudormobile.FinancialData;
 
 public partial interface IFinancialDataClient
 {
     // Supress warnings to document unsupported api endpoints.
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+    Task<FinancialDataResponse<List<MutualFundStatistics>>> GetMutualFundStatisticsAsync(string identifier, int offset = 0, CancellationToken cancellationToken = default)
+        => FinancialDataResponse<List<MutualFundStatistics>>.PremiumSubscriptionNotImplemented();
+    Task<FinancialDataResponse<List<MutualFundHoldings>>> GetMutualFundHoldingsAsync(string identifier, int offset = 0, CancellationToken cancellationToken = default)
+        => FinancialDataResponse<List<MutualFundHoldings>>.PremiumSubscriptionNotImplemented();
+    Task<FinancialDataResponse<List<MutualFundSymbol>>> GetMutualFundSymbolsAsync(int offset = 0, CancellationToken cancellationToken = default)
+        => FinancialDataResponse<List<MutualFundSymbol>>.PremiumSubscriptionNotImplemented();
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or members
 }

--- a/src/FinancialData/ApiEndpoints/IFinancialDataClient.SymbolLists.cs
+++ b/src/FinancialData/ApiEndpoints/IFinancialDataClient.SymbolLists.cs
@@ -47,7 +47,7 @@ public partial interface IFinancialDataClient
     /// See: https://financialdata.net/documentation#operation/getEtfSymbols
     /// </remarks>
     Task<FinancialDataResponse<List<Symbol>>> GetEtfSymbolsAsync(int offset = 0, CancellationToken cancellationToken = default)
-        => GetApiResultAsync<List<Symbol>>($"international-stock-symbols?offset={offset}", cancellationToken);
+        => GetApiResultAsync<List<Symbol>>($"etf-symbols?offset={offset}", cancellationToken);
 
     /// <summary>
     /// Retrieves a list of commodity symbols.

--- a/src/FinancialData/Entities/BalanceSheet.cs
+++ b/src/FinancialData/Entities/BalanceSheet.cs
@@ -10,157 +10,157 @@
 public record BalanceSheet
 {
     /// <summary>
-    /// Gets or sets the trading symbol of the security.
+    /// Gets the trading symbol of the security.
     /// </summary>
     public string? TradingSymbol { get; init; }
 
     /// <summary>
-    /// Gets or sets the unique identifier for the central index associated with this balance sheet.
+    /// Gets the unique identifier for the central index associated with this balance sheet.
     /// </summary>
     public string? CentralIndexKey { get; init; }
 
     /// <summary>
-    /// Gets or sets the registrant name.
+    /// Gets the registrant name.
     /// </summary>
     public string? RegistrantName { get; init; }
 
     /// <summary>
-    /// Gets or sets the fiscal year.
+    /// Gets the fiscal year.
     /// </summary>
     public string? FiscalYear { get; init; }
 
     /// <summary>
-    /// Gets or sets the fiscal period associated with the financial data.
+    /// Gets the fiscal period associated with the financial data.
     /// </summary>
     public string? FiscalPeriod { get; init; }
 
     /// <summary>
-    /// Gets or sets the period end date.
+    /// Gets the period end date.
     /// </summary>
     public DateOnly PeriodEndDate { get; init; }
 
     /// <summary>
-    /// Gets or sets cash and cash equivalents.
+    /// Gets cash and cash equivalents.
     /// </summary>
     public decimal CashAndCashEquivalents { get; init; }
 
     /// <summary>
-    /// Gets or sets the value of marketable securities classified as current assets on the balance sheet.
+    /// Gets the value of marketable securities classified as current assets on the balance sheet.
     /// </summary>
     public decimal MarketableSecuritiesCurrent { get; init; }
 
     /// <summary>
-    /// Gets or sets accounts receivable.
+    /// Gets accounts receivable.
     /// </summary>
     public decimal AccountsReceivable { get; init; }
 
     /// <summary>
-    /// Gets or sets inventories.
+    /// Gets inventories.
     /// </summary>
     public decimal Inventories { get; init; }
 
     /// <summary>
-    /// Gets or sets non-trade receivables.
+    /// Gets non-trade receivables.
     /// </summary>
     public decimal NonTradeReceivables { get; init; }
 
     /// <summary>
-    /// Gets or sets other current assets.
+    /// Gets other current assets.
     /// </summary>
     public decimal OtherAssetsCurrent { get; init; }
 
     /// <summary>
-    /// Gets or sets total current assets.
+    /// Gets total current assets.
     /// </summary>
     public decimal TotalAssetsCurrent { get; init; }
 
     /// <summary>
-    /// Gets or sets non-current marketable securities.
+    /// Gets non-current marketable securities.
     /// </summary>
     public decimal MarketableSecuritiesNonCurrent { get; init; }
 
     /// <summary>
-    /// Gets or sets property, plant, and equipment.
+    /// Gets property, plant, and equipment.
     /// </summary>
     public decimal PropertyPlantAndEquipment { get; init; }
 
     /// <summary>
-    /// Gets or sets other non-current assets.
+    /// Gets other non-current assets.
     /// </summary>
     public decimal OtherAssetsNonCurrent { get; init; }
 
     /// <summary>
-    /// Gets or sets total non-current assets.
+    /// Gets total non-current assets.
     /// </summary>
     public decimal TotalAssetsNonCurrent { get; init; }
 
     /// <summary>
-    /// Gets or sets total assets.
+    /// Gets total assets.
     /// </summary>
     public decimal TotalAssets { get; init; }
 
     /// <summary>
-    /// Gets or sets accounts payable.
+    /// Gets accounts payable.
     /// </summary>
     public decimal AccountsPayable { get; init; }
 
     /// <summary>
-    /// Gets or sets deferred revenue.
+    /// Gets deferred revenue.
     /// </summary>
     public decimal DeferredRevenue { get; init; }
 
     /// <summary>
-    /// Gets or sets short-term debt.
+    /// Gets short-term debt.
     /// </summary>
     public decimal ShortTermDebt { get; init; }
 
     /// <summary>
-    /// Gets or sets other current liabilities.
+    /// Gets other current liabilities.
     /// </summary>
     public decimal OtherLiabilitiesCurrent { get; init; }
 
     /// <summary>
-    /// Gets or sets total current liabilities.
+    /// Gets total current liabilities.
     /// </summary>
     public decimal TotalLiabilitiesCurrent { get; init; }
 
     /// <summary>
-    /// Gets or sets long-term debt.
+    /// Gets long-term debt.
     /// </summary>
     public decimal LongTermDebt { get; init; }
 
     /// <summary>
-    /// Gets or sets other non-current liabilities.
+    /// Gets other non-current liabilities.
     /// </summary>
     public decimal OtherLiabilitiesNonCurrent { get; init; }
 
     /// <summary>
-    /// Gets or sets total non-current liabilities.
+    /// Gets total non-current liabilities.
     /// </summary>
     public decimal TotalLiabilitiesNonCurrent { get; init; }
 
     /// <summary>
-    /// Gets or sets total liabilities.
+    /// Gets total liabilities.
     /// </summary>
     public decimal TotalLiabilities { get; init; }
 
     /// <summary>
-    /// Gets or sets common stock.
+    /// Gets common stock.
     /// </summary>
     public decimal CommonStock { get; init; }
 
     /// <summary>
-    /// Gets or sets retained earnings.
+    /// Gets retained earnings.
     /// </summary>
     public decimal RetainedEarnings { get; init; }
 
     /// <summary>
-    /// Gets or sets accumulated other comprehensive income.
+    /// Gets accumulated other comprehensive income.
     /// </summary>
     public decimal AccumulatedOtherComprehensiveIncome { get; init; }
 
     /// <summary>
-    /// Gets or sets total shareholders' equity.
+    /// Gets total shareholders' equity.
     /// </summary>
     public decimal TotalShareholdersEquity { get; init; }
 

--- a/src/FinancialData/Entities/BalanceSheet.cs
+++ b/src/FinancialData/Entities/BalanceSheet.cs
@@ -10,159 +10,159 @@
 public record BalanceSheet
 {
     /// <summary>
-    /// 
+    /// Gets or sets the trading symbol of the security.
     /// </summary>
-    public string? TradingSymbol { get; set; }
+    public string? TradingSymbol { get; init; }
 
     /// <summary>
     /// Gets or sets the unique identifier for the central index associated with this balance sheet.
     /// </summary>
-    public string? CentralIndexKey { get; set; }
+    public string? CentralIndexKey { get; init; }
 
     /// <summary>
-    /// 
+    /// Gets or sets the registrant name.
     /// </summary>
-    public string? RegistrantName { get; set; }
+    public string? RegistrantName { get; init; }
 
     /// <summary>
-    /// 
+    /// Gets or sets the fiscal year.
     /// </summary>
-    public string? FiscalYear { get; set; }
+    public string? FiscalYear { get; init; }
 
     /// <summary>
     /// Gets or sets the fiscal period associated with the financial data.
     /// </summary>
-    public string? FiscalPeriod { get; set; }
+    public string? FiscalPeriod { get; init; }
 
     /// <summary>
-    /// 
+    /// Gets or sets the period end date.
     /// </summary>
-    public DateOnly? PeriodEndDate { get; set; }
+    public DateOnly PeriodEndDate { get; init; }
 
     /// <summary>
-    /// 
+    /// Gets or sets cash and cash equivalents.
     /// </summary>
-    public decimal? CashAndCashEquivalents { get; set; }
+    public decimal CashAndCashEquivalents { get; init; }
 
     /// <summary>
     /// Gets or sets the value of marketable securities classified as current assets on the balance sheet.
     /// </summary>
-    public decimal? MarketableSecuritiesCurrent { get; set; }
+    public decimal MarketableSecuritiesCurrent { get; init; }
 
     /// <summary>
-    /// 
+    /// Gets or sets accounts receivable.
     /// </summary>
-    public decimal? AccountsReceivable { get; set; }
+    public decimal AccountsReceivable { get; init; }
 
     /// <summary>
-    /// 
+    /// Gets or sets inventories.
     /// </summary>
-    public decimal? Inventories { get; set; }
+    public decimal Inventories { get; init; }
 
     /// <summary>
-    /// 
+    /// Gets or sets non-trade receivables.
     /// </summary>
-    public object? NonTradeReceivables { get; set; }
+    public decimal NonTradeReceivables { get; init; }
 
     /// <summary>
-    /// 
+    /// Gets or sets other current assets.
     /// </summary>
-    public decimal? OtherAssetsCurrent { get; set; }
+    public decimal OtherAssetsCurrent { get; init; }
 
     /// <summary>
-    /// 
+    /// Gets or sets total current assets.
     /// </summary>
-    public decimal? TotalAssetsCurrent { get; set; }
+    public decimal TotalAssetsCurrent { get; init; }
 
     /// <summary>
-    /// 
+    /// Gets or sets non-current marketable securities.
     /// </summary>
-    public decimal? MarketableSecuritiesNonCurrent { get; set; }
+    public decimal MarketableSecuritiesNonCurrent { get; init; }
 
     /// <summary>
-    /// 
+    /// Gets or sets property, plant, and equipment.
     /// </summary>
-    public decimal? PropertyPlantAndEquipment { get; set; }
+    public decimal PropertyPlantAndEquipment { get; init; }
 
     /// <summary>
-    /// 
+    /// Gets or sets other non-current assets.
     /// </summary>
-    public decimal? OtherAssetsNonCurrent { get; set; }
+    public decimal OtherAssetsNonCurrent { get; init; }
 
     /// <summary>
-    /// 
+    /// Gets or sets total non-current assets.
     /// </summary>
-    public decimal? TotalAssetsNonCurrent { get; set; }
+    public decimal TotalAssetsNonCurrent { get; init; }
 
     /// <summary>
-    /// 
+    /// Gets or sets total assets.
     /// </summary>
-    public decimal? TotalAssets { get; set; }
+    public decimal TotalAssets { get; init; }
 
     /// <summary>
-    /// 
+    /// Gets or sets accounts payable.
     /// </summary>
-    public decimal? AccountsPayable { get; set; }
+    public decimal AccountsPayable { get; init; }
 
     /// <summary>
-    /// 
+    /// Gets or sets deferred revenue.
     /// </summary>
-    public decimal? DeferredRevenue { get; set; }
+    public decimal DeferredRevenue { get; init; }
 
     /// <summary>
-    /// 
+    /// Gets or sets short-term debt.
     /// </summary>
-    public decimal? ShortTermDebt { get; set; }
+    public decimal ShortTermDebt { get; init; }
 
     /// <summary>
-    /// 
+    /// Gets or sets other current liabilities.
     /// </summary>
-    public decimal? OtherLiabilitiesCurrent { get; set; }
+    public decimal OtherLiabilitiesCurrent { get; init; }
 
     /// <summary>
-    /// 
+    /// Gets or sets total current liabilities.
     /// </summary>
-    public decimal? TotalLiabilitiesCurrent { get; set; }
+    public decimal TotalLiabilitiesCurrent { get; init; }
 
     /// <summary>
-    /// 
+    /// Gets or sets long-term debt.
     /// </summary>
-    public decimal? LongTermDebt { get; set; }
+    public decimal LongTermDebt { get; init; }
 
     /// <summary>
-    /// 
+    /// Gets or sets other non-current liabilities.
     /// </summary>
-    public decimal? OtherLiabilitiesNonCurrent { get; set; }
+    public decimal OtherLiabilitiesNonCurrent { get; init; }
 
     /// <summary>
-    /// 
+    /// Gets or sets total non-current liabilities.
     /// </summary>
-    public decimal? TotalLiabilitiesNonCurrent { get; set; }
+    public decimal TotalLiabilitiesNonCurrent { get; init; }
 
     /// <summary>
-    /// 
+    /// Gets or sets total liabilities.
     /// </summary>
-    public decimal? TotalLiabilities { get; set; }
+    public decimal TotalLiabilities { get; init; }
 
     /// <summary>
-    /// 
+    /// Gets or sets common stock.
     /// </summary>
-    public decimal? CommonStock { get; set; }
+    public decimal CommonStock { get; init; }
 
     /// <summary>
-    /// 
+    /// Gets or sets retained earnings.
     /// </summary>
-    public decimal? RetainedEarnings { get; set; }
+    public decimal RetainedEarnings { get; init; }
 
     /// <summary>
-    /// 
+    /// Gets or sets accumulated other comprehensive income.
     /// </summary>
-    public decimal? AccumulatedOtherComprehensiveIncome { get; set; }
+    public decimal AccumulatedOtherComprehensiveIncome { get; init; }
 
     /// <summary>
-    /// 
+    /// Gets or sets total shareholders' equity.
     /// </summary>
-    public decimal? TotalShareholdersEquity { get; set; }
+    public decimal TotalShareholdersEquity { get; init; }
 
 }
 

--- a/src/FinancialData/Entities/CompanyInformation.cs
+++ b/src/FinancialData/Entities/CompanyInformation.cs
@@ -1,0 +1,158 @@
+namespace Tudormobile.FinancialData.Entities;
+
+/// <summary>
+/// Represents basic company information including LEI number, industry, contact information, and other key facts.
+/// <para>See: https://financialdata.net/documentation#company_information</para>
+/// </summary>
+public record CompanyInformation
+{
+    /// <summary>
+    /// Gets or sets the trading symbol of the company.
+    /// </summary>
+    public string? TradingSymbol { get; init; }
+
+    /// <summary>
+    /// Gets or sets the central index key (CIK) assigned by the SEC.
+    /// </summary>
+    public string? CentralIndexKey { get; init; }
+
+    /// <summary>
+    /// Gets or sets the registrant name of the company.
+    /// </summary>
+    public string? RegistrantName { get; init; }
+
+    /// <summary>
+    /// Gets or sets the ISIN (International Securities Identification Number).
+    /// </summary>
+    public string? IsinNumber { get; init; }
+
+    /// <summary>
+    /// Gets or sets the LEI (Legal Entity Identifier) number.
+    /// </summary>
+    public string? LeiNumber { get; init; }
+
+    /// <summary>
+    /// Gets or sets the EIN (Employer Identification Number).
+    /// </summary>
+    public string? EinNumber { get; init; }
+
+    /// <summary>
+    /// Gets or sets the stock exchange where the company is listed.
+    /// </summary>
+    public string? Exchange { get; init; }
+
+    /// <summary>
+    /// Gets or sets the SIC (Standard Industrial Classification) code.
+    /// </summary>
+    public string? SicCode { get; init; }
+
+    /// <summary>
+    /// Gets or sets the SIC description.
+    /// </summary>
+    public string? SicDescription { get; init; }
+
+    /// <summary>
+    /// Gets or sets the fiscal year end (MMDD format).
+    /// </summary>
+    public string? FiscalYearEnd { get; init; }
+
+    /// <summary>
+    /// Gets or sets the state of incorporation.
+    /// </summary>
+    public string? StateOfIncorporation { get; init; }
+
+    /// <summary>
+    /// Gets or sets the street address.
+    /// </summary>
+    public string? AddressStreet { get; init; }
+
+    /// <summary>
+    /// Gets or sets the city of the address.
+    /// </summary>
+    public string? AddressCity { get; init; }
+
+    /// <summary>
+    /// Gets or sets the state of the address.
+    /// </summary>
+    public string? AddressState { get; init; }
+
+    /// <summary>
+    /// Gets or sets the ZIP code of the address.
+    /// </summary>
+    public string? AddressZipCode { get; init; }
+
+    /// <summary>
+    /// Gets or sets the country of the address.
+    /// </summary>
+    public string? AddressCountry { get; init; }
+
+    /// <summary>
+    /// Gets or sets the country code of the address.
+    /// </summary>
+    public string? AddressCountryCode { get; init; }
+
+    /// <summary>
+    /// Gets or sets the phone number.
+    /// </summary>
+    public string? PhoneNumber { get; init; }
+
+    /// <summary>
+    /// Gets or sets the mailing address.
+    /// </summary>
+    public string? MailingAddress { get; init; }
+
+    /// <summary>
+    /// Gets or sets the business address.
+    /// </summary>
+    public string? BusinessAddress { get; init; }
+
+    /// <summary>
+    /// Gets or sets the former name of the company.
+    /// </summary>
+    public string? FormerName { get; init; }
+
+    /// <summary>
+    /// Gets or sets the industry classification.
+    /// </summary>
+    public string? Industry { get; init; }
+
+    /// <summary>
+    /// Gets or sets the founding date.
+    /// </summary>
+    public string? FoundingDate { get; init; }
+
+    /// <summary>
+    /// Gets or sets the name of the chief executive officer.
+    /// </summary>
+    public string? ChiefExecutiveOfficer { get; init; }
+
+    /// <summary>
+    /// Gets or sets the number of employees.
+    /// </summary>
+    public int NumberOfEmployees { get; init; }
+
+    /// <summary>
+    /// Gets or sets the company website URL.
+    /// </summary>
+    public string? Website { get; init; }
+
+    /// <summary>
+    /// Gets or sets the market capitalization.
+    /// </summary>
+    public decimal MarketCap { get; init; }
+
+    /// <summary>
+    /// Gets or sets the number of shares issued.
+    /// </summary>
+    public decimal SharesIssued { get; init; }
+
+    /// <summary>
+    /// Gets or sets the number of shares outstanding.
+    /// </summary>
+    public decimal SharesOutstanding { get; init; }
+
+    /// <summary>
+    /// Gets or sets the company description.
+    /// </summary>
+    public string? Description { get; init; }
+}

--- a/src/FinancialData/Entities/CompanyInformation.cs
+++ b/src/FinancialData/Entities/CompanyInformation.cs
@@ -7,152 +7,152 @@ namespace Tudormobile.FinancialData.Entities;
 public record CompanyInformation
 {
     /// <summary>
-    /// Gets or sets the trading symbol of the company.
+    /// Gets the trading symbol of the company.
     /// </summary>
     public string? TradingSymbol { get; init; }
 
     /// <summary>
-    /// Gets or sets the central index key (CIK) assigned by the SEC.
+    /// Gets the central index key (CIK) assigned by the SEC.
     /// </summary>
     public string? CentralIndexKey { get; init; }
 
     /// <summary>
-    /// Gets or sets the registrant name of the company.
+    /// Gets the registrant name of the company.
     /// </summary>
     public string? RegistrantName { get; init; }
 
     /// <summary>
-    /// Gets or sets the ISIN (International Securities Identification Number).
+    /// Gets the ISIN (International Securities Identification Number).
     /// </summary>
     public string? IsinNumber { get; init; }
 
     /// <summary>
-    /// Gets or sets the LEI (Legal Entity Identifier) number.
+    /// Gets the LEI (Legal Entity Identifier) number.
     /// </summary>
     public string? LeiNumber { get; init; }
 
     /// <summary>
-    /// Gets or sets the EIN (Employer Identification Number).
+    /// Gets the EIN (Employer Identification Number).
     /// </summary>
     public string? EinNumber { get; init; }
 
     /// <summary>
-    /// Gets or sets the stock exchange where the company is listed.
+    /// Gets the stock exchange where the company is listed.
     /// </summary>
     public string? Exchange { get; init; }
 
     /// <summary>
-    /// Gets or sets the SIC (Standard Industrial Classification) code.
+    /// Gets the SIC (Standard Industrial Classification) code.
     /// </summary>
     public string? SicCode { get; init; }
 
     /// <summary>
-    /// Gets or sets the SIC description.
+    /// Gets the SIC description.
     /// </summary>
     public string? SicDescription { get; init; }
 
     /// <summary>
-    /// Gets or sets the fiscal year end (MMDD format).
+    /// Gets the fiscal year end (MMDD format).
     /// </summary>
     public string? FiscalYearEnd { get; init; }
 
     /// <summary>
-    /// Gets or sets the state of incorporation.
+    /// Gets the state of incorporation.
     /// </summary>
     public string? StateOfIncorporation { get; init; }
 
     /// <summary>
-    /// Gets or sets the street address.
+    /// Gets the street address.
     /// </summary>
     public string? AddressStreet { get; init; }
 
     /// <summary>
-    /// Gets or sets the city of the address.
+    /// Gets the city of the address.
     /// </summary>
     public string? AddressCity { get; init; }
 
     /// <summary>
-    /// Gets or sets the state of the address.
+    /// Gets the state of the address.
     /// </summary>
     public string? AddressState { get; init; }
 
     /// <summary>
-    /// Gets or sets the ZIP code of the address.
+    /// Gets the ZIP code of the address.
     /// </summary>
     public string? AddressZipCode { get; init; }
 
     /// <summary>
-    /// Gets or sets the country of the address.
+    /// Gets the country of the address.
     /// </summary>
     public string? AddressCountry { get; init; }
 
     /// <summary>
-    /// Gets or sets the country code of the address.
+    /// Gets the country code of the address.
     /// </summary>
     public string? AddressCountryCode { get; init; }
 
     /// <summary>
-    /// Gets or sets the phone number.
+    /// Gets the phone number.
     /// </summary>
     public string? PhoneNumber { get; init; }
 
     /// <summary>
-    /// Gets or sets the mailing address.
+    /// Gets the mailing address.
     /// </summary>
     public string? MailingAddress { get; init; }
 
     /// <summary>
-    /// Gets or sets the business address.
+    /// Gets the business address.
     /// </summary>
     public string? BusinessAddress { get; init; }
 
     /// <summary>
-    /// Gets or sets the former name of the company.
+    /// Gets the former name of the company.
     /// </summary>
     public string? FormerName { get; init; }
 
     /// <summary>
-    /// Gets or sets the industry classification.
+    /// Gets the industry classification.
     /// </summary>
     public string? Industry { get; init; }
 
     /// <summary>
-    /// Gets or sets the founding date.
+    /// Gets the founding date.
     /// </summary>
     public string? FoundingDate { get; init; }
 
     /// <summary>
-    /// Gets or sets the name of the chief executive officer.
+    /// Gets the name of the chief executive officer.
     /// </summary>
     public string? ChiefExecutiveOfficer { get; init; }
 
     /// <summary>
-    /// Gets or sets the number of employees.
+    /// Gets the number of employees.
     /// </summary>
     public int NumberOfEmployees { get; init; }
 
     /// <summary>
-    /// Gets or sets the company website URL.
+    /// Gets the company website URL.
     /// </summary>
     public string? Website { get; init; }
 
     /// <summary>
-    /// Gets or sets the market capitalization.
+    /// Gets the market capitalization.
     /// </summary>
     public decimal MarketCap { get; init; }
 
     /// <summary>
-    /// Gets or sets the number of shares issued.
+    /// Gets the number of shares issued.
     /// </summary>
     public decimal SharesIssued { get; init; }
 
     /// <summary>
-    /// Gets or sets the number of shares outstanding.
+    /// Gets the number of shares outstanding.
     /// </summary>
     public decimal SharesOutstanding { get; init; }
 
     /// <summary>
-    /// Gets or sets the company description.
+    /// Gets the company description.
     /// </summary>
     public string? Description { get; init; }
 }

--- a/src/FinancialData/Entities/CryptoInformation.cs
+++ b/src/FinancialData/Entities/CryptoInformation.cs
@@ -7,32 +7,32 @@ namespace Tudormobile.FinancialData.Entities;
 public record CryptoInformation
 {
     /// <summary>
-    /// Gets or sets the trading symbol of the cryptocurrency.
+    /// Gets the trading symbol of the cryptocurrency.
     /// </summary>
     public string? TradingSymbol { get; init; }
 
     /// <summary>
-    /// Gets or sets the full name of the cryptocurrency.
+    /// Gets the full name of the cryptocurrency.
     /// </summary>
     public string? Name { get; init; }
 
     /// <summary>
-    /// Gets or sets the website URL.
+    /// Gets the website URL.
     /// </summary>
     public string? Website { get; init; }
 
     /// <summary>
-    /// Gets or sets the description of the cryptocurrency.
+    /// Gets the description of the cryptocurrency.
     /// </summary>
     public string? Description { get; init; }
 
     /// <summary>
-    /// Gets or sets the founding date.
+    /// Gets the founding date.
     /// </summary>
     public string? FoundingDate { get; init; }
 
     /// <summary>
-    /// Gets or sets the name of the founder(s).
+    /// Gets the name of the founder(s).
     /// </summary>
     public string? Founder { get; init; }
 }

--- a/src/FinancialData/Entities/CryptoInformation.cs
+++ b/src/FinancialData/Entities/CryptoInformation.cs
@@ -1,0 +1,38 @@
+namespace Tudormobile.FinancialData.Entities;
+
+/// <summary>
+/// Represents detailed information about a cryptocurrency including website, description, and founding information.
+/// <para>See: https://financialdata.net/documentation#crypto_information</para>
+/// </summary>
+public record CryptoInformation
+{
+    /// <summary>
+    /// Gets or sets the trading symbol of the cryptocurrency.
+    /// </summary>
+    public string? TradingSymbol { get; init; }
+
+    /// <summary>
+    /// Gets or sets the full name of the cryptocurrency.
+    /// </summary>
+    public string? Name { get; init; }
+
+    /// <summary>
+    /// Gets or sets the website URL.
+    /// </summary>
+    public string? Website { get; init; }
+
+    /// <summary>
+    /// Gets or sets the description of the cryptocurrency.
+    /// </summary>
+    public string? Description { get; init; }
+
+    /// <summary>
+    /// Gets or sets the founding date.
+    /// </summary>
+    public string? FoundingDate { get; init; }
+
+    /// <summary>
+    /// Gets or sets the name of the founder(s).
+    /// </summary>
+    public string? Founder { get; init; }
+}

--- a/src/FinancialData/Entities/CryptoMinutePrice.cs
+++ b/src/FinancialData/Entities/CryptoMinutePrice.cs
@@ -7,37 +7,37 @@ namespace Tudormobile.FinancialData.Entities;
 public record CryptoMinutePrice
 {
     /// <summary>
-    /// Gets or sets the trading symbol of the cryptocurrency.
+    /// Gets the trading symbol of the cryptocurrency.
     /// </summary>
     public string? TradingSymbol { get; init; }
 
     /// <summary>
-    /// Gets or sets the timestamp of the minute price record (UTC).
+    /// Gets the timestamp of the minute price record (UTC).
     /// </summary>
     public DateTime Time { get; init; }
 
     /// <summary>
-    /// Gets or sets the opening price for the one-minute period.
+    /// Gets the opening price for the one-minute period.
     /// </summary>
     public decimal Open { get; init; }
 
     /// <summary>
-    /// Gets or sets the highest price during the one-minute period.
+    /// Gets the highest price during the one-minute period.
     /// </summary>
     public decimal High { get; init; }
 
     /// <summary>
-    /// Gets or sets the lowest price during the one-minute period.
+    /// Gets the lowest price during the one-minute period.
     /// </summary>
     public decimal Low { get; init; }
 
     /// <summary>
-    /// Gets or sets the closing price for the one-minute period.
+    /// Gets the closing price for the one-minute period.
     /// </summary>
     public decimal Close { get; init; }
 
     /// <summary>
-    /// Gets or sets the trading volume for the one-minute period.
+    /// Gets the trading volume for the one-minute period.
     /// </summary>
     public decimal Volume { get; init; }
 }

--- a/src/FinancialData/Entities/CryptoMinutePrice.cs
+++ b/src/FinancialData/Entities/CryptoMinutePrice.cs
@@ -1,0 +1,43 @@
+namespace Tudormobile.FinancialData.Entities;
+
+/// <summary>
+/// Represents one-minute historical price data for a cryptocurrency.
+/// <para>See: https://financialdata.net/documentation#crypto_minute_prices</para>
+/// </summary>
+public record CryptoMinutePrice
+{
+    /// <summary>
+    /// Gets or sets the trading symbol of the cryptocurrency.
+    /// </summary>
+    public string? TradingSymbol { get; init; }
+
+    /// <summary>
+    /// Gets or sets the timestamp of the minute price record (UTC).
+    /// </summary>
+    public DateTime Time { get; init; }
+
+    /// <summary>
+    /// Gets or sets the opening price for the one-minute period.
+    /// </summary>
+    public decimal Open { get; init; }
+
+    /// <summary>
+    /// Gets or sets the highest price during the one-minute period.
+    /// </summary>
+    public decimal High { get; init; }
+
+    /// <summary>
+    /// Gets or sets the lowest price during the one-minute period.
+    /// </summary>
+    public decimal Low { get; init; }
+
+    /// <summary>
+    /// Gets or sets the closing price for the one-minute period.
+    /// </summary>
+    public decimal Close { get; init; }
+
+    /// <summary>
+    /// Gets or sets the trading volume for the one-minute period.
+    /// </summary>
+    public decimal Volume { get; init; }
+}

--- a/src/FinancialData/Entities/CryptoPrice.cs
+++ b/src/FinancialData/Entities/CryptoPrice.cs
@@ -7,42 +7,42 @@ namespace Tudormobile.FinancialData.Entities;
 public record CryptoPrice
 {
     /// <summary>
-    /// Gets or sets the trading symbol of the cryptocurrency.
+    /// Gets the trading symbol of the cryptocurrency.
     /// </summary>
     public string? TradingSymbol { get; init; }
 
     /// <summary>
-    /// Gets or sets the date of the price record.
+    /// Gets the date of the price record.
     /// </summary>
     public DateOnly Date { get; init; }
 
     /// <summary>
-    /// Gets or sets the opening price.
+    /// Gets the opening price.
     /// </summary>
     public decimal Open { get; init; }
 
     /// <summary>
-    /// Gets or sets the highest price.
+    /// Gets the highest price.
     /// </summary>
     public decimal High { get; init; }
 
     /// <summary>
-    /// Gets or sets the lowest price.
+    /// Gets the lowest price.
     /// </summary>
     public decimal Low { get; init; }
 
     /// <summary>
-    /// Gets or sets the closing price.
+    /// Gets the closing price.
     /// </summary>
     public decimal Close { get; init; }
 
     /// <summary>
-    /// Gets or sets the trading volume.
+    /// Gets the trading volume.
     /// </summary>
     public decimal Volume { get; init; }
 
     /// <summary>
-    /// Gets or sets the market capitalization.
+    /// Gets the market capitalization.
     /// </summary>
     public decimal MarketCap { get; init; }
 }

--- a/src/FinancialData/Entities/CryptoPrice.cs
+++ b/src/FinancialData/Entities/CryptoPrice.cs
@@ -1,0 +1,48 @@
+namespace Tudormobile.FinancialData.Entities;
+
+/// <summary>
+/// Represents daily historical price data for a cryptocurrency.
+/// <para>See: https://financialdata.net/documentation#crypto_prices</para>
+/// </summary>
+public record CryptoPrice
+{
+    /// <summary>
+    /// Gets or sets the trading symbol of the cryptocurrency.
+    /// </summary>
+    public string? TradingSymbol { get; init; }
+
+    /// <summary>
+    /// Gets or sets the date of the price record.
+    /// </summary>
+    public DateOnly Date { get; init; }
+
+    /// <summary>
+    /// Gets or sets the opening price.
+    /// </summary>
+    public decimal Open { get; init; }
+
+    /// <summary>
+    /// Gets or sets the highest price.
+    /// </summary>
+    public decimal High { get; init; }
+
+    /// <summary>
+    /// Gets or sets the lowest price.
+    /// </summary>
+    public decimal Low { get; init; }
+
+    /// <summary>
+    /// Gets or sets the closing price.
+    /// </summary>
+    public decimal Close { get; init; }
+
+    /// <summary>
+    /// Gets or sets the trading volume.
+    /// </summary>
+    public decimal Volume { get; init; }
+
+    /// <summary>
+    /// Gets or sets the market capitalization.
+    /// </summary>
+    public decimal MarketCap { get; init; }
+}

--- a/src/FinancialData/Entities/CryptoQuote.cs
+++ b/src/FinancialData/Entities/CryptoQuote.cs
@@ -1,0 +1,38 @@
+namespace Tudormobile.FinancialData.Entities;
+
+/// <summary>
+/// Represents real-time quote data for a cryptocurrency including price, volume, and market cap.
+/// <para>See: https://financialdata.net/documentation#crypto_quotes</para>
+/// </summary>
+public record CryptoQuote
+{
+    /// <summary>
+    /// Gets or sets the trading symbol of the cryptocurrency.
+    /// </summary>
+    public string? TradingSymbol { get; init; }
+
+    /// <summary>
+    /// Gets or sets the timestamp of the quote (UTC).
+    /// </summary>
+    public DateTime Time { get; init; }
+
+    /// <summary>
+    /// Gets or sets the current price.
+    /// </summary>
+    public decimal Price { get; init; }
+
+    /// <summary>
+    /// Gets or sets the 24-hour trading volume.
+    /// </summary>
+    public decimal Volume { get; init; }
+
+    /// <summary>
+    /// Gets or sets the market capitalization.
+    /// </summary>
+    public decimal MarketCap { get; init; }
+
+    /// <summary>
+    /// Gets or sets the 24-hour price change percentage.
+    /// </summary>
+    public decimal PercentChange { get; init; }
+}

--- a/src/FinancialData/Entities/CryptoQuote.cs
+++ b/src/FinancialData/Entities/CryptoQuote.cs
@@ -7,32 +7,32 @@ namespace Tudormobile.FinancialData.Entities;
 public record CryptoQuote
 {
     /// <summary>
-    /// Gets or sets the trading symbol of the cryptocurrency.
+    /// Gets the trading symbol of the cryptocurrency.
     /// </summary>
     public string? TradingSymbol { get; init; }
 
     /// <summary>
-    /// Gets or sets the timestamp of the quote (UTC).
+    /// Gets the timestamp of the quote (UTC).
     /// </summary>
     public DateTime Time { get; init; }
 
     /// <summary>
-    /// Gets or sets the current price.
+    /// Gets the current price.
     /// </summary>
     public decimal Price { get; init; }
 
     /// <summary>
-    /// Gets or sets the 24-hour trading volume.
+    /// Gets the 24-hour trading volume.
     /// </summary>
     public decimal Volume { get; init; }
 
     /// <summary>
-    /// Gets or sets the market capitalization.
+    /// Gets the market capitalization.
     /// </summary>
     public decimal MarketCap { get; init; }
 
     /// <summary>
-    /// Gets or sets the 24-hour price change percentage.
+    /// Gets the 24-hour price change percentage.
     /// </summary>
     public decimal PercentChange { get; init; }
 }

--- a/src/FinancialData/Entities/CryptoSymbol.cs
+++ b/src/FinancialData/Entities/CryptoSymbol.cs
@@ -7,12 +7,12 @@ namespace Tudormobile.FinancialData.Entities;
 public record CryptoSymbol
 {
     /// <summary>
-    /// Gets or sets the trading symbol of the cryptocurrency.
+    /// Gets the trading symbol of the cryptocurrency.
     /// </summary>
     public string? TradingSymbol { get; init; }
 
     /// <summary>
-    /// Gets or sets the full name of the cryptocurrency.
+    /// Gets the full name of the cryptocurrency.
     /// </summary>
     public string? Name { get; init; }
 }

--- a/src/FinancialData/Entities/CryptoSymbol.cs
+++ b/src/FinancialData/Entities/CryptoSymbol.cs
@@ -1,0 +1,18 @@
+namespace Tudormobile.FinancialData.Entities;
+
+/// <summary>
+/// Represents a cryptocurrency symbol and its full name.
+/// <para>See: https://financialdata.net/documentation#crypto_symbols</para>
+/// </summary>
+public record CryptoSymbol
+{
+    /// <summary>
+    /// Gets or sets the trading symbol of the cryptocurrency.
+    /// </summary>
+    public string? TradingSymbol { get; init; }
+
+    /// <summary>
+    /// Gets or sets the full name of the cryptocurrency.
+    /// </summary>
+    public string? Name { get; init; }
+}

--- a/src/FinancialData/Entities/Dividend.cs
+++ b/src/FinancialData/Entities/Dividend.cs
@@ -1,0 +1,48 @@
+namespace Tudormobile.FinancialData.Entities;
+
+/// <summary>
+/// Represents dividend information including type, amount, and key dates.
+/// <para>See: https://financialdata.net/documentation#dividends</para>
+/// </summary>
+public record Dividend
+{
+    /// <summary>
+    /// Gets or sets the trading symbol of the company.
+    /// </summary>
+    public string? TradingSymbol { get; init; }
+
+    /// <summary>
+    /// Gets or sets the registrant name of the company.
+    /// </summary>
+    public string? RegistrantName { get; init; }
+
+    /// <summary>
+    /// Gets or sets the type of dividend (e.g., "Cash").
+    /// </summary>
+    public string? Type { get; init; }
+
+    /// <summary>
+    /// Gets or sets the dividend amount per share.
+    /// </summary>
+    public decimal Amount { get; init; }
+
+    /// <summary>
+    /// Gets or sets the declaration date.
+    /// </summary>
+    public DateOnly DeclarationDate { get; init; }
+
+    /// <summary>
+    /// Gets or sets the ex-dividend date.
+    /// </summary>
+    public DateOnly ExDate { get; init; }
+
+    /// <summary>
+    /// Gets or sets the record date.
+    /// </summary>
+    public DateOnly RecordDate { get; init; }
+
+    /// <summary>
+    /// Gets or sets the payment date.
+    /// </summary>
+    public DateOnly PaymentDate { get; init; }
+}

--- a/src/FinancialData/Entities/Dividend.cs
+++ b/src/FinancialData/Entities/Dividend.cs
@@ -7,42 +7,42 @@ namespace Tudormobile.FinancialData.Entities;
 public record Dividend
 {
     /// <summary>
-    /// Gets or sets the trading symbol of the company.
+    /// Gets the trading symbol of the company.
     /// </summary>
     public string? TradingSymbol { get; init; }
 
     /// <summary>
-    /// Gets or sets the registrant name of the company.
+    /// Gets the registrant name of the company.
     /// </summary>
     public string? RegistrantName { get; init; }
 
     /// <summary>
-    /// Gets or sets the type of dividend (e.g., "Cash").
+    /// Gets the type of dividend (e.g., "Cash").
     /// </summary>
     public string? Type { get; init; }
 
     /// <summary>
-    /// Gets or sets the dividend amount per share.
+    /// Gets the dividend amount per share.
     /// </summary>
     public decimal Amount { get; init; }
 
     /// <summary>
-    /// Gets or sets the declaration date.
+    /// Gets the declaration date.
     /// </summary>
     public DateOnly DeclarationDate { get; init; }
 
     /// <summary>
-    /// Gets or sets the ex-dividend date.
+    /// Gets the ex-dividend date.
     /// </summary>
     public DateOnly ExDate { get; init; }
 
     /// <summary>
-    /// Gets or sets the record date.
+    /// Gets the record date.
     /// </summary>
     public DateOnly RecordDate { get; init; }
 
     /// <summary>
-    /// Gets or sets the payment date.
+    /// Gets the payment date.
     /// </summary>
     public DateOnly PaymentDate { get; init; }
 }

--- a/src/FinancialData/Entities/DividendsCalendar.cs
+++ b/src/FinancialData/Entities/DividendsCalendar.cs
@@ -1,0 +1,43 @@
+namespace Tudormobile.FinancialData.Entities;
+
+/// <summary>
+/// Represents an upcoming dividend payment on the dividends calendar.
+/// <para>See: https://financialdata.net/documentation#dividends_calendar</para>
+/// </summary>
+public record DividendsCalendar
+{
+    /// <summary>
+    /// Gets or sets the trading symbol of the company.
+    /// </summary>
+    public string? TradingSymbol { get; init; }
+
+    /// <summary>
+    /// Gets or sets the registrant name of the company.
+    /// </summary>
+    public string? RegistrantName { get; init; }
+
+    /// <summary>
+    /// Gets or sets the dividend amount per share.
+    /// </summary>
+    public decimal Amount { get; init; }
+
+    /// <summary>
+    /// Gets or sets the declaration date.
+    /// </summary>
+    public DateOnly DeclarationDate { get; init; }
+
+    /// <summary>
+    /// Gets or sets the ex-dividend date.
+    /// </summary>
+    public DateOnly ExDate { get; init; }
+
+    /// <summary>
+    /// Gets or sets the record date.
+    /// </summary>
+    public DateOnly RecordDate { get; init; }
+
+    /// <summary>
+    /// Gets or sets the payment date.
+    /// </summary>
+    public DateOnly PaymentDate { get; init; }
+}

--- a/src/FinancialData/Entities/DividendsCalendar.cs
+++ b/src/FinancialData/Entities/DividendsCalendar.cs
@@ -7,37 +7,37 @@ namespace Tudormobile.FinancialData.Entities;
 public record DividendsCalendar
 {
     /// <summary>
-    /// Gets or sets the trading symbol of the company.
+    /// Gets the trading symbol of the company.
     /// </summary>
     public string? TradingSymbol { get; init; }
 
     /// <summary>
-    /// Gets or sets the registrant name of the company.
+    /// Gets the registrant name of the company.
     /// </summary>
     public string? RegistrantName { get; init; }
 
     /// <summary>
-    /// Gets or sets the dividend amount per share.
+    /// Gets the dividend amount per share.
     /// </summary>
     public decimal Amount { get; init; }
 
     /// <summary>
-    /// Gets or sets the declaration date.
+    /// Gets the declaration date.
     /// </summary>
     public DateOnly DeclarationDate { get; init; }
 
     /// <summary>
-    /// Gets or sets the ex-dividend date.
+    /// Gets the ex-dividend date.
     /// </summary>
     public DateOnly ExDividendDate { get; init; }
 
     /// <summary>
-    /// Gets or sets the record date.
+    /// Gets the record date.
     /// </summary>
     public DateOnly RecordDate { get; init; }
 
     /// <summary>
-    /// Gets or sets the payment date.
+    /// Gets the payment date.
     /// </summary>
     public DateOnly PaymentDate { get; init; }
 }

--- a/src/FinancialData/Entities/DividendsCalendar.cs
+++ b/src/FinancialData/Entities/DividendsCalendar.cs
@@ -29,7 +29,7 @@ public record DividendsCalendar
     /// <summary>
     /// Gets or sets the ex-dividend date.
     /// </summary>
-    public DateOnly ExDate { get; init; }
+    public DateOnly ExDividendDate { get; init; }
 
     /// <summary>
     /// Gets or sets the record date.

--- a/src/FinancialData/Entities/EarningsCalendar.cs
+++ b/src/FinancialData/Entities/EarningsCalendar.cs
@@ -7,32 +7,32 @@ namespace Tudormobile.FinancialData.Entities;
 public record EarningsCalendar
 {
     /// <summary>
-    /// Gets or sets the trading symbol of the company.
+    /// Gets the trading symbol of the company.
     /// </summary>
     public string? TradingSymbol { get; init; }
 
     /// <summary>
-    /// Gets or sets the registrant name of the company.
+    /// Gets the registrant name of the company.
     /// </summary>
     public string? RegistrantName { get; init; }
 
     /// <summary>
-    /// Gets or sets the fiscal quarter end date.
+    /// Gets the fiscal quarter end date.
     /// </summary>
     public string? FiscalQuarterEndDate { get; init; }
 
     /// <summary>
-    /// Gets or sets the report date.
+    /// Gets the report date.
     /// </summary>
     public DateOnly ReportDate { get; init; }
 
     /// <summary>
-    /// Gets or sets the conference call time (EST).
+    /// Gets the conference call time (EST).
     /// </summary>
     public DateTime ConferenceCallTime { get; init; }
 
     /// <summary>
-    /// Gets or sets the forecasted earnings per share.
+    /// Gets the forecasted earnings per share.
     /// </summary>
     public decimal EarningsPerShareForecast { get; init; }
 }

--- a/src/FinancialData/Entities/EarningsCalendar.cs
+++ b/src/FinancialData/Entities/EarningsCalendar.cs
@@ -1,0 +1,38 @@
+namespace Tudormobile.FinancialData.Entities;
+
+/// <summary>
+/// Represents an upcoming earnings release on the earnings calendar.
+/// <para>See: https://financialdata.net/documentation#earnings_calendar</para>
+/// </summary>
+public record EarningsCalendar
+{
+    /// <summary>
+    /// Gets or sets the trading symbol of the company.
+    /// </summary>
+    public string? TradingSymbol { get; init; }
+
+    /// <summary>
+    /// Gets or sets the registrant name of the company.
+    /// </summary>
+    public string? RegistrantName { get; init; }
+
+    /// <summary>
+    /// Gets or sets the fiscal quarter end date.
+    /// </summary>
+    public string? FiscalQuarterEndDate { get; init; }
+
+    /// <summary>
+    /// Gets or sets the report date.
+    /// </summary>
+    public DateOnly ReportDate { get; init; }
+
+    /// <summary>
+    /// Gets or sets the conference call time (EST).
+    /// </summary>
+    public DateTime ConferenceCallTime { get; init; }
+
+    /// <summary>
+    /// Gets or sets the forecasted earnings per share.
+    /// </summary>
+    public decimal EarningsPerShareForecast { get; init; }
+}

--- a/src/FinancialData/Entities/EarningsRelease.cs
+++ b/src/FinancialData/Entities/EarningsRelease.cs
@@ -7,52 +7,52 @@ namespace Tudormobile.FinancialData.Entities;
 public record EarningsRelease
 {
     /// <summary>
-    /// Gets or sets the trading symbol of the company.
+    /// Gets the trading symbol of the company.
     /// </summary>
     public string? TradingSymbol { get; init; }
 
     /// <summary>
-    /// Gets or sets the central index key (CIK) assigned by the SEC.
+    /// Gets the central index key (CIK) assigned by the SEC.
     /// </summary>
     public string? CentralIndexKey { get; init; }
 
     /// <summary>
-    /// Gets or sets the registrant name of the company.
+    /// Gets the registrant name of the company.
     /// </summary>
     public string? RegistrantName { get; init; }
 
     /// <summary>
-    /// Gets or sets the market capitalization.
+    /// Gets the market capitalization.
     /// </summary>
     public decimal MarketCap { get; init; }
 
     /// <summary>
-    /// Gets or sets the fiscal quarter end date.
+    /// Gets the fiscal quarter end date.
     /// </summary>
     public string? FiscalQuarterEndDate { get; init; }
 
     /// <summary>
-    /// Gets or sets the actual earnings per share.
+    /// Gets the actual earnings per share.
     /// </summary>
     public decimal EarningsPerShare { get; init; }
 
     /// <summary>
-    /// Gets or sets the forecasted earnings per share.
+    /// Gets the forecasted earnings per share.
     /// </summary>
     public decimal EarningsPerShareForecast { get; init; }
 
     /// <summary>
-    /// Gets or sets the percentage surprise (difference between actual and forecast).
+    /// Gets the percentage surprise (difference between actual and forecast).
     /// </summary>
     public decimal PercentageSurprise { get; init; }
 
     /// <summary>
-    /// Gets or sets the number of analyst forecasts.
+    /// Gets the number of analyst forecasts.
     /// </summary>
     public int NumberOfForecasts { get; init; }
 
     /// <summary>
-    /// Gets or sets the conference call time (EST).
+    /// Gets the conference call time (EST).
     /// </summary>
     public DateTime ConferenceCallTime { get; init; }
 }

--- a/src/FinancialData/Entities/EarningsRelease.cs
+++ b/src/FinancialData/Entities/EarningsRelease.cs
@@ -1,0 +1,58 @@
+namespace Tudormobile.FinancialData.Entities;
+
+/// <summary>
+/// Represents earnings release information including actual and predicted earnings, release timing, and market cap.
+/// <para>See: https://financialdata.net/documentation#earnings_releases</para>
+/// </summary>
+public record EarningsRelease
+{
+    /// <summary>
+    /// Gets or sets the trading symbol of the company.
+    /// </summary>
+    public string? TradingSymbol { get; init; }
+
+    /// <summary>
+    /// Gets or sets the central index key (CIK) assigned by the SEC.
+    /// </summary>
+    public string? CentralIndexKey { get; init; }
+
+    /// <summary>
+    /// Gets or sets the registrant name of the company.
+    /// </summary>
+    public string? RegistrantName { get; init; }
+
+    /// <summary>
+    /// Gets or sets the market capitalization.
+    /// </summary>
+    public decimal MarketCap { get; init; }
+
+    /// <summary>
+    /// Gets or sets the fiscal quarter end date.
+    /// </summary>
+    public string? FiscalQuarterEndDate { get; init; }
+
+    /// <summary>
+    /// Gets or sets the actual earnings per share.
+    /// </summary>
+    public decimal EarningsPerShare { get; init; }
+
+    /// <summary>
+    /// Gets or sets the forecasted earnings per share.
+    /// </summary>
+    public decimal EarningsPerShareForecast { get; init; }
+
+    /// <summary>
+    /// Gets or sets the percentage surprise (difference between actual and forecast).
+    /// </summary>
+    public decimal PercentageSurprise { get; init; }
+
+    /// <summary>
+    /// Gets or sets the number of analyst forecasts.
+    /// </summary>
+    public int NumberOfForecasts { get; init; }
+
+    /// <summary>
+    /// Gets or sets the conference call time (EST).
+    /// </summary>
+    public DateTime ConferenceCallTime { get; init; }
+}

--- a/src/FinancialData/Entities/EconomicCalendar.cs
+++ b/src/FinancialData/Entities/EconomicCalendar.cs
@@ -7,32 +7,32 @@ namespace Tudormobile.FinancialData.Entities;
 public record EconomicCalendar
 {
     /// <summary>
-    /// Gets or sets the name of the economic event or indicator.
+    /// Gets the name of the economic event or indicator.
     /// </summary>
     public string? EventName { get; init; }
 
     /// <summary>
-    /// Gets or sets the country of the event.
+    /// Gets the country of the event.
     /// </summary>
     public string? Country { get; init; }
 
     /// <summary>
-    /// Gets or sets the country code.
+    /// Gets the country code.
     /// </summary>
     public string? CountryCode { get; init; }
 
     /// <summary>
-    /// Gets or sets the time of the event (EST).
+    /// Gets the time of the event (EST).
     /// </summary>
     public DateTime Time { get; init; }
 
     /// <summary>
-    /// Gets or sets the previous indicator value.
+    /// Gets the previous indicator value.
     /// </summary>
     public decimal PreviousValue { get; init; }
 
     /// <summary>
-    /// Gets or sets the actual indicator value.
+    /// Gets the actual indicator value.
     /// </summary>
     public decimal ActualValue { get; init; }
 }

--- a/src/FinancialData/Entities/EconomicCalendar.cs
+++ b/src/FinancialData/Entities/EconomicCalendar.cs
@@ -1,0 +1,38 @@
+namespace Tudormobile.FinancialData.Entities;
+
+/// <summary>
+/// Represents an upcoming economic event or indicator announcement on the economic calendar.
+/// <para>See: https://financialdata.net/documentation#economic_calendar</para>
+/// </summary>
+public record EconomicCalendar
+{
+    /// <summary>
+    /// Gets or sets the name of the economic event or indicator.
+    /// </summary>
+    public string? EventName { get; init; }
+
+    /// <summary>
+    /// Gets or sets the country of the event.
+    /// </summary>
+    public string? Country { get; init; }
+
+    /// <summary>
+    /// Gets or sets the country code.
+    /// </summary>
+    public string? CountryCode { get; init; }
+
+    /// <summary>
+    /// Gets or sets the time of the event (EST).
+    /// </summary>
+    public DateTime Time { get; init; }
+
+    /// <summary>
+    /// Gets or sets the previous indicator value.
+    /// </summary>
+    public decimal PreviousValue { get; init; }
+
+    /// <summary>
+    /// Gets or sets the actual indicator value.
+    /// </summary>
+    public decimal ActualValue { get; init; }
+}

--- a/src/FinancialData/Entities/EmployeeCount.cs
+++ b/src/FinancialData/Entities/EmployeeCount.cs
@@ -7,27 +7,27 @@ namespace Tudormobile.FinancialData.Entities;
 public record EmployeeCount
 {
     /// <summary>
-    /// Gets or sets the trading symbol of the company.
+    /// Gets the trading symbol of the company.
     /// </summary>
     public string? TradingSymbol { get; init; }
 
     /// <summary>
-    /// Gets or sets the central index key (CIK) assigned by the SEC.
+    /// Gets the central index key (CIK) assigned by the SEC.
     /// </summary>
     public string? CentralIndexKey { get; init; }
 
     /// <summary>
-    /// Gets or sets the registrant name of the company.
+    /// Gets the registrant name of the company.
     /// </summary>
     public string? RegistrantName { get; init; }
 
     /// <summary>
-    /// Gets or sets the fiscal year.
+    /// Gets the fiscal year.
     /// </summary>
     public string? FiscalYear { get; init; }
 
     /// <summary>
-    /// Gets or sets the number of employees.
+    /// Gets the number of employees.
     /// </summary>
     public int Count { get; init; }
 }

--- a/src/FinancialData/Entities/EmployeeCount.cs
+++ b/src/FinancialData/Entities/EmployeeCount.cs
@@ -1,0 +1,33 @@
+namespace Tudormobile.FinancialData.Entities;
+
+/// <summary>
+/// Represents the total number of employees for a company in a particular year.
+/// <para>See: https://financialdata.net/documentation#employee_count</para>
+/// </summary>
+public record EmployeeCount
+{
+    /// <summary>
+    /// Gets or sets the trading symbol of the company.
+    /// </summary>
+    public string? TradingSymbol { get; init; }
+
+    /// <summary>
+    /// Gets or sets the central index key (CIK) assigned by the SEC.
+    /// </summary>
+    public string? CentralIndexKey { get; init; }
+
+    /// <summary>
+    /// Gets or sets the registrant name of the company.
+    /// </summary>
+    public string? RegistrantName { get; init; }
+
+    /// <summary>
+    /// Gets or sets the fiscal year.
+    /// </summary>
+    public string? FiscalYear { get; init; }
+
+    /// <summary>
+    /// Gets or sets the number of employees.
+    /// </summary>
+    public int Count { get; init; }
+}

--- a/src/FinancialData/Entities/EsgRating.cs
+++ b/src/FinancialData/Entities/EsgRating.cs
@@ -1,0 +1,48 @@
+namespace Tudormobile.FinancialData.Entities;
+
+/// <summary>
+/// Represents ESG rating classification for a company.
+/// <para>See: https://financialdata.net/documentation#esg_ratings</para>
+/// </summary>
+public record EsgRating
+{
+    /// <summary>
+    /// Gets or sets the trading symbol of the company.
+    /// </summary>
+    public string? TradingSymbol { get; init; }
+
+    /// <summary>
+    /// Gets or sets the central index key (CIK) assigned by the SEC.
+    /// </summary>
+    public string? CentralIndexKey { get; init; }
+
+    /// <summary>
+    /// Gets or sets the registrant name of the company.
+    /// </summary>
+    public string? RegistrantName { get; init; }
+
+    /// <summary>
+    /// Gets or sets the date of the ESG rating.
+    /// </summary>
+    public DateOnly Date { get; init; }
+
+    /// <summary>
+    /// Gets or sets the overall ESG rating (e.g., AAA, AA, A, BBB, BB, B, CCC).
+    /// </summary>
+    public string? Rating { get; init; }
+
+    /// <summary>
+    /// Gets or sets the environmental rating.
+    /// </summary>
+    public string? EnvironmentalRating { get; init; }
+
+    /// <summary>
+    /// Gets or sets the social rating.
+    /// </summary>
+    public string? SocialRating { get; init; }
+
+    /// <summary>
+    /// Gets or sets the governance rating.
+    /// </summary>
+    public string? GovernanceRating { get; init; }
+}

--- a/src/FinancialData/Entities/EsgRating.cs
+++ b/src/FinancialData/Entities/EsgRating.cs
@@ -7,42 +7,42 @@ namespace Tudormobile.FinancialData.Entities;
 public record EsgRating
 {
     /// <summary>
-    /// Gets or sets the trading symbol of the company.
+    /// Gets the trading symbol of the company.
     /// </summary>
     public string? TradingSymbol { get; init; }
 
     /// <summary>
-    /// Gets or sets the central index key (CIK) assigned by the SEC.
+    /// Gets the central index key (CIK) assigned by the SEC.
     /// </summary>
     public string? CentralIndexKey { get; init; }
 
     /// <summary>
-    /// Gets or sets the registrant name of the company.
+    /// Gets the registrant name of the company.
     /// </summary>
     public string? RegistrantName { get; init; }
 
     /// <summary>
-    /// Gets or sets the date of the ESG rating.
+    /// Gets the date of the ESG rating.
     /// </summary>
     public DateOnly Date { get; init; }
 
     /// <summary>
-    /// Gets or sets the overall ESG rating (e.g., AAA, AA, A, BBB, BB, B, CCC).
+    /// Gets the overall ESG rating (e.g., AAA, AA, A, BBB, BB, B, CCC).
     /// </summary>
     public string? Rating { get; init; }
 
     /// <summary>
-    /// Gets or sets the environmental rating.
+    /// Gets the environmental rating.
     /// </summary>
     public string? EnvironmentalRating { get; init; }
 
     /// <summary>
-    /// Gets or sets the social rating.
+    /// Gets the social rating.
     /// </summary>
     public string? SocialRating { get; init; }
 
     /// <summary>
-    /// Gets or sets the governance rating.
+    /// Gets the governance rating.
     /// </summary>
     public string? GovernanceRating { get; init; }
 }

--- a/src/FinancialData/Entities/EsgScore.cs
+++ b/src/FinancialData/Entities/EsgScore.cs
@@ -1,0 +1,53 @@
+namespace Tudormobile.FinancialData.Entities;
+
+/// <summary>
+/// Represents ESG (Environmental, Social, Governance) scores for a company.
+/// <para>See: https://financialdata.net/documentation#esg_scores</para>
+/// </summary>
+public record EsgScore
+{
+    /// <summary>
+    /// Gets or sets the trading symbol of the company.
+    /// </summary>
+    public string? TradingSymbol { get; init; }
+
+    /// <summary>
+    /// Gets or sets the central index key (CIK) assigned by the SEC.
+    /// </summary>
+    public string? CentralIndexKey { get; init; }
+
+    /// <summary>
+    /// Gets or sets the registrant name of the company.
+    /// </summary>
+    public string? RegistrantName { get; init; }
+
+    /// <summary>
+    /// Gets or sets the date of the ESG score.
+    /// </summary>
+    public DateOnly Date { get; init; }
+
+    /// <summary>
+    /// Gets or sets the overall ESG score.
+    /// </summary>
+    public decimal TotalScore { get; init; }
+
+    /// <summary>
+    /// Gets or sets the environmental score.
+    /// </summary>
+    public decimal EnvironmentalScore { get; init; }
+
+    /// <summary>
+    /// Gets or sets the social score.
+    /// </summary>
+    public decimal SocialScore { get; init; }
+
+    /// <summary>
+    /// Gets or sets the governance score.
+    /// </summary>
+    public decimal GovernanceScore { get; init; }
+
+    /// <summary>
+    /// Gets or sets the controversy score.
+    /// </summary>
+    public decimal ControversyScore { get; init; }
+}

--- a/src/FinancialData/Entities/EsgScore.cs
+++ b/src/FinancialData/Entities/EsgScore.cs
@@ -7,47 +7,47 @@ namespace Tudormobile.FinancialData.Entities;
 public record EsgScore
 {
     /// <summary>
-    /// Gets or sets the trading symbol of the company.
+    /// Gets the trading symbol of the company.
     /// </summary>
     public string? TradingSymbol { get; init; }
 
     /// <summary>
-    /// Gets or sets the central index key (CIK) assigned by the SEC.
+    /// Gets the central index key (CIK) assigned by the SEC.
     /// </summary>
     public string? CentralIndexKey { get; init; }
 
     /// <summary>
-    /// Gets or sets the registrant name of the company.
+    /// Gets the registrant name of the company.
     /// </summary>
     public string? RegistrantName { get; init; }
 
     /// <summary>
-    /// Gets or sets the date of the ESG score.
+    /// Gets the date of the ESG score.
     /// </summary>
     public DateOnly Date { get; init; }
 
     /// <summary>
-    /// Gets or sets the overall ESG score.
+    /// Gets the overall ESG score.
     /// </summary>
     public decimal TotalScore { get; init; }
 
     /// <summary>
-    /// Gets or sets the environmental score.
+    /// Gets the environmental score.
     /// </summary>
     public decimal EnvironmentalScore { get; init; }
 
     /// <summary>
-    /// Gets or sets the social score.
+    /// Gets the social score.
     /// </summary>
     public decimal SocialScore { get; init; }
 
     /// <summary>
-    /// Gets or sets the governance score.
+    /// Gets the governance score.
     /// </summary>
     public decimal GovernanceScore { get; init; }
 
     /// <summary>
-    /// Gets or sets the controversy score.
+    /// Gets the controversy score.
     /// </summary>
     public decimal ControversyScore { get; init; }
 }

--- a/src/FinancialData/Entities/EtfHoldings.cs
+++ b/src/FinancialData/Entities/EtfHoldings.cs
@@ -7,137 +7,137 @@ namespace Tudormobile.FinancialData.Entities;
 public record EtfHoldings
 {
     /// <summary>
-    /// Gets or sets the unique central index key for the ETF.
+    /// Gets the unique central index key for the ETF.
     /// </summary>
     public string? CentralIndexKey { get; init; }
 
     /// <summary>
-    /// Gets or sets the name of the registrant (ETF provider).
+    /// Gets the name of the registrant (ETF provider).
     /// </summary>
     public string? RegistrantName { get; init; }
 
     /// <summary>
-    /// Gets or sets the period of report (end date of the reporting period).
+    /// Gets the period of report (end date of the reporting period).
     /// </summary>
     public DateOnly? PeriodOfReport { get; init; }
 
     /// <summary>
-    /// Gets or sets the name of the ETF.
+    /// Gets the name of the ETF.
     /// </summary>
     public string? EtfName { get; init; }
 
     /// <summary>
-    /// Gets or sets the symbol of the ETF.
+    /// Gets the symbol of the ETF.
     /// </summary>
     public string? EtfSymbol { get; init; }
 
     /// <summary>
-    /// Gets or sets the series ID of the ETF.
+    /// Gets the series ID of the ETF.
     /// </summary>
     public string? SeriesId { get; init; }
 
     /// <summary>
-    /// Gets or sets the class ID of the ETF.
+    /// Gets the class ID of the ETF.
     /// </summary>
     public string? ClassId { get; init; }
 
     /// <summary>
-    /// Gets or sets the issuer name of the holding.
+    /// Gets the issuer name of the holding.
     /// </summary>
     public string? IssuerName { get; init; }
 
     /// <summary>
-    /// Gets or sets the Legal Entity Identifier (LEI) number of the issuer.
+    /// Gets the Legal Entity Identifier (LEI) number of the issuer.
     /// </summary>
     public string? LeiNumber { get; init; }
 
     /// <summary>
-    /// Gets or sets the title of the security.
+    /// Gets the title of the security.
     /// </summary>
     public string? TitleOfSecurity { get; init; }
 
     /// <summary>
-    /// Gets or sets the trading symbol of the security.
+    /// Gets the trading symbol of the security.
     /// </summary>
     public string? TradingSymbol { get; init; }
 
     /// <summary>
-    /// Gets or sets the CUSIP number of the security.
+    /// Gets the CUSIP number of the security.
     /// </summary>
     public string? CusipNumber { get; init; }
 
     /// <summary>
-    /// Gets or sets the ISIN number of the security.
+    /// Gets the ISIN number of the security.
     /// </summary>
     public string? IsinNumber { get; init; }
 
     /// <summary>
-    /// Gets or sets the amount of units held.
+    /// Gets the amount of units held.
     /// </summary>
-    public decimal? AmountOfUnits { get; init; }
+    public decimal AmountOfUnits { get; init; }
 
     /// <summary>
-    /// Gets or sets the description of units.
+    /// Gets the description of units.
     /// </summary>
     public string? DescriptionOfUnits { get; init; }
 
     /// <summary>
-    /// Gets or sets the denomination currency.
+    /// Gets the denomination currency.
     /// </summary>
     public string? DenominationCurrency { get; init; }
 
     /// <summary>
-    /// Gets or sets the value in USD.
+    /// Gets the value in USD.
     /// </summary>
-    public decimal? ValueInUsd { get; init; }
+    public decimal ValueInUsd { get; init; }
 
     /// <summary>
-    /// Gets or sets the percentage value compared to assets.
+    /// Gets the percentage value compared to assets.
     /// </summary>
-    public decimal? PercentageValueComparedToAssets { get; init; }
+    public decimal PercentageValueComparedToAssets { get; init; }
 
     /// <summary>
-    /// Gets or sets the payoff profile (e.g., Long/Short).
+    /// Gets the payoff profile (e.g., Long/Short).
     /// </summary>
     public string? PayoffProfile { get; init; }
 
     /// <summary>
-    /// Gets or sets the asset type.
+    /// Gets the asset type.
     /// </summary>
     public string? AssetType { get; init; }
 
     /// <summary>
-    /// Gets or sets the issuer type.
+    /// Gets the issuer type.
     /// </summary>
     public string? IssuerType { get; init; }
 
     /// <summary>
-    /// Gets or sets the country of issuer or investment.
+    /// Gets the country of issuer or investment.
     /// </summary>
     public string? CountryOfIssuerOrInvestment { get; init; }
 
     /// <summary>
-    /// Gets or sets a value indicating whether the security is restricted.
+    /// Gets a value indicating whether the security is restricted.
     /// </summary>
     public bool? IsRestrictedSecurity { get; init; }
 
     /// <summary>
-    /// Gets or sets the fair value level.
+    /// Gets the fair value level.
     /// </summary>
     public int? FairValueLevel { get; init; }
 
     /// <summary>
-    /// Gets or sets a value indicating whether this is cash collateral.
+    /// Gets a value indicating whether this is cash collateral.
     /// </summary>
     public bool? IsCashCollateral { get; init; }
 
     /// <summary>
-    /// Gets or sets a value indicating whether this is non-cash collateral.
+    /// Gets a value indicating whether this is non-cash collateral.
     /// </summary>
     public bool? IsNonCashCollateral { get; init; }
 
     /// <summary>
-    /// Gets or sets a value indicating whether this is a loan by the fund.
+    /// Gets a value indicating whether this is a loan by the fund.
     /// </summary>
     public bool? IsLoanByFund { get; init; }
 }

--- a/src/FinancialData/Entities/EtfHoldings.cs
+++ b/src/FinancialData/Entities/EtfHoldings.cs
@@ -1,0 +1,175 @@
+namespace Tudormobile.FinancialData.Entities;
+
+/// <summary>
+/// Represents a holding within an ETF, including issuer, security, value, and collateral information.
+/// <para>See: https://financialdata.net/documentation#ETF_holdings</para>
+/// </summary>
+public record EtfHoldings
+{
+    // TODO: Define properties based on API response or JSON sample
+    /// <summary>
+    /// Gets or sets the unique central index key for the ETF.
+    /// </summary>
+    public string? CentralIndexKey { get; init; }
+
+    /// <summary>
+    /// Gets or sets the name of the registrant (ETF provider).
+    /// </summary>
+    public string? RegistrantName { get; init; }
+
+    /// <summary>
+    /// Gets or sets the period of report (end date of the reporting period).
+    /// </summary>
+    public DateOnly? PeriodOfReport { get; init; }
+
+    /// <summary>
+    /// Gets or sets the name of the ETF.
+    /// </summary>
+    public string? EtfName { get; init; }
+
+    /// <summary>
+    /// Gets or sets the symbol of the ETF.
+    /// </summary>
+    public string? EtfSymbol { get; init; }
+
+    /// <summary>
+    /// Gets or sets the series ID of the ETF.
+    /// </summary>
+    public string? SeriesId { get; init; }
+
+    /// <summary>
+    /// Gets or sets the class ID of the ETF.
+    /// </summary>
+    public string? ClassId { get; init; }
+
+    /// <summary>
+    /// Gets or sets the issuer name of the holding.
+    /// </summary>
+    public string? IssuerName { get; init; }
+
+    /// <summary>
+    /// Gets or sets the Legal Entity Identifier (LEI) number of the issuer.
+    /// </summary>
+    public string? LeiNumber { get; init; }
+
+    /// <summary>
+    /// Gets or sets the title of the security.
+    /// </summary>
+    public string? TitleOfSecurity { get; init; }
+
+    /// <summary>
+    /// Gets or sets the trading symbol of the security.
+    /// </summary>
+    public string? TradingSymbol { get; init; }
+
+    /// <summary>
+    /// Gets or sets the CUSIP number of the security.
+    /// </summary>
+    public string? CusipNumber { get; init; }
+
+    /// <summary>
+    /// Gets or sets the ISIN number of the security.
+    /// </summary>
+    public string? IsinNumber { get; init; }
+
+    /// <summary>
+    /// Gets or sets the amount of units held.
+    /// </summary>
+    public decimal? AmountOfUnits { get; init; }
+
+    /// <summary>
+    /// Gets or sets the description of units.
+    /// </summary>
+    public string? DescriptionOfUnits { get; init; }
+
+    /// <summary>
+    /// Gets or sets the denomination currency.
+    /// </summary>
+    public string? DenominationCurrency { get; init; }
+
+    /// <summary>
+    /// Gets or sets the value in USD.
+    /// </summary>
+    public decimal? ValueInUsd { get; init; }
+
+    /// <summary>
+    /// Gets or sets the percentage value compared to assets.
+    /// </summary>
+    public decimal? PercentageValueComparedToAssets { get; init; }
+
+    /// <summary>
+    /// Gets or sets the payoff profile (e.g., Long/Short).
+    /// </summary>
+    public string? PayoffProfile { get; init; }
+
+    /// <summary>
+    /// Gets or sets the asset type.
+    /// </summary>
+    public string? AssetType { get; init; }
+
+    /// <summary>
+    /// Gets or sets the issuer type.
+    /// </summary>
+    public string? IssuerType { get; init; }
+
+    /// <summary>
+    /// Gets or sets the country of issuer or investment.
+    /// </summary>
+    public string? CountryOfIssuerOrInvestment { get; init; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the security is restricted.
+    /// </summary>
+    public bool? IsRestrictedSecurity { get; init; }
+
+    /// <summary>
+    /// Gets or sets the fair value level.
+    /// </summary>
+    public int? FairValueLevel { get; init; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether this is cash collateral.
+    /// </summary>
+    public bool? IsCashCollateral { get; init; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether this is non-cash collateral.
+    /// </summary>
+    public bool? IsNonCashCollateral { get; init; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether this is a loan by the fund.
+    /// </summary>
+    public bool? IsLoanByFund { get; init; }
+}
+/* ref: https://financialdata.net/documentation#ETF_holdings
+{
+    "central_index_key": "0000884394",
+    "registrant_name": "SPDR S&P 500 ETF TRUST",
+    "period_of_report": "2025-06-30",
+    "etf_name": "SPDR S&P 500 ETF TRUST",
+    "etf_symbol": "SPY",
+    "series_id": "N/A",
+    "class_id": "N/A",
+    "issuer_name": "Johnson & Johnson",
+    "lei_number": "549300G0CFPGEF6X2043",
+    "title_of_security": "Johnson & Johnson",
+    "trading_symbol": "JNJ",
+    "cusip_number": "478160104",
+    "isin_number": "US4781601046",
+    "amount_of_units": 29181009,
+    "description_of_units": "NS",
+    "denomination_currency": "USD",
+    "value_in_usd": 4457399124.75,
+    "percentage_value_compared_to_assets": 0.699985772661,
+    "payoff_profile": "Long",
+    "asset_type": "EC",
+    "issuer_type": "CORP",
+    "country_of_issuer_or_investment": "US",
+    "is_restricted_security": false,
+    "fair_value_level": 1,
+    "is_cash_collateral": false,
+    "is_non_cash_collateral": false,
+    "is_loan_by_fund": false
+  }
+*/

--- a/src/FinancialData/Entities/EtfHoldings.cs
+++ b/src/FinancialData/Entities/EtfHoldings.cs
@@ -6,7 +6,6 @@ namespace Tudormobile.FinancialData.Entities;
 /// </summary>
 public record EtfHoldings
 {
-    // TODO: Define properties based on API response or JSON sample
     /// <summary>
     /// Gets or sets the unique central index key for the ETF.
     /// </summary>

--- a/src/FinancialData/Entities/EtfPrices.cs
+++ b/src/FinancialData/Entities/EtfPrices.cs
@@ -1,0 +1,54 @@
+namespace Tudormobile.FinancialData.Entities;
+
+/// <summary>
+/// Represents daily price information for an ETF, including open, high, low, close, and volume.
+/// <para>See: https://financialdata.net/documentation#ETF_prices</para>
+/// </summary>
+public record EtfPrices
+{
+    /// <summary>
+    /// Gets or sets the trading symbol of the ETF.
+    /// </summary>
+    public string? TradingSymbol { get; init; }
+
+    /// <summary>
+    /// Gets or sets the date of the price record.
+    /// </summary>
+    public DateOnly? Date { get; init; }
+
+    /// <summary>
+    /// Gets or sets the opening price of the ETF for the trading period.
+    /// </summary>
+    public decimal? Open { get; init; }
+
+    /// <summary>
+    /// Gets or sets the highest price recorded during the trading period.
+    /// </summary>
+    public decimal? High { get; init; }
+
+    /// <summary>
+    /// Gets or sets the lowest price recorded during the trading period.
+    /// </summary>
+    public decimal? Low { get; init; }
+
+    /// <summary>
+    /// Gets or sets the closing price of the ETF for the trading period.
+    /// </summary>
+    public decimal? Close { get; init; }
+
+    /// <summary>
+    /// Gets or sets the total traded volume for the ETF.
+    /// </summary>
+    public decimal? Volume { get; init; }
+}
+/* ref: https://financialdata.net/documentation#ETF_prices
+{
+    "trading_symbol": "SPY",
+    "date": "2024-12-03",
+    "open": 603.39,
+    "high": 604.16,
+    "low": 602.341,
+    "close": 603.91,
+    "volume": 26906630.0
+  }
+*/

--- a/src/FinancialData/Entities/EtfPrices.cs
+++ b/src/FinancialData/Entities/EtfPrices.cs
@@ -7,39 +7,39 @@ namespace Tudormobile.FinancialData.Entities;
 public record EtfPrices
 {
     /// <summary>
-    /// Gets or sets the trading symbol of the ETF.
+    /// Gets the trading symbol of the ETF.
     /// </summary>
     public string? TradingSymbol { get; init; }
 
     /// <summary>
-    /// Gets or sets the date of the price record.
+    /// Gets the date of the price record.
     /// </summary>
     public DateOnly? Date { get; init; }
 
     /// <summary>
-    /// Gets or sets the opening price of the ETF for the trading period.
+    /// Gets the opening price of the ETF for the trading period.
     /// </summary>
-    public decimal? Open { get; init; }
+    public decimal Open { get; init; }
 
     /// <summary>
-    /// Gets or sets the highest price recorded during the trading period.
+    /// Gets the highest price recorded during the trading period.
     /// </summary>
-    public decimal? High { get; init; }
+    public decimal High { get; init; }
 
     /// <summary>
-    /// Gets or sets the lowest price recorded during the trading period.
+    /// Gets the lowest price recorded during the trading period.
     /// </summary>
-    public decimal? Low { get; init; }
+    public decimal Low { get; init; }
 
     /// <summary>
-    /// Gets or sets the closing price of the ETF for the trading period.
+    /// Gets the closing price of the ETF for the trading period.
     /// </summary>
-    public decimal? Close { get; init; }
+    public decimal Close { get; init; }
 
     /// <summary>
-    /// Gets or sets the total traded volume for the ETF.
+    /// Gets the total traded volume for the ETF.
     /// </summary>
-    public decimal? Volume { get; init; }
+    public decimal Volume { get; init; }
 }
 /* ref: https://financialdata.net/documentation#ETF_prices
 {

--- a/src/FinancialData/Entities/EtfQuotes.cs
+++ b/src/FinancialData/Entities/EtfQuotes.cs
@@ -1,0 +1,49 @@
+namespace Tudormobile.FinancialData.Entities;
+
+/// <summary>
+/// Represents a real-time or recent quote for an ETF, including price, change, and percentage change.
+/// <para>See: https://financialdata.net/documentation#ETF_quotes</para>
+/// </summary>
+public record EtfQuotes
+{
+    // TODO: Define properties based on API response or JSON sample
+    /// <summary>
+    /// Gets or sets the trading symbol of the ETF.
+    /// </summary>
+    public string? TradingSymbol { get; init; }
+
+    /// <summary>
+    /// Gets or sets the description of the ETF.
+    /// </summary>
+    public string? Description { get; init; }
+
+    /// <summary>
+    /// Gets or sets the time of the quote.
+    /// </summary>
+    public DateTime? Time { get; init; }
+
+    /// <summary>
+    /// Gets or sets the current price of the ETF.
+    /// </summary>
+    public decimal? Price { get; init; }
+
+    /// <summary>
+    /// Gets or sets the price change.
+    /// </summary>
+    public decimal? Change { get; init; }
+
+    /// <summary>
+    /// Gets or sets the percentage change in price.
+    /// </summary>
+    public decimal? PercentageChange { get; init; }
+}
+/* ref: https://financialdata.net/documentation#ETF_quotes
+{
+    "trading_symbol": "SPY",
+    "description": "SPDR S&P 500 ETF Trust",
+    "time": "2025-09-02 15:59:30",
+    "price": 642.41,
+    "change": 2.14,
+    "percentage_change": 0.33
+  }
+*/

--- a/src/FinancialData/Entities/EtfQuotes.cs
+++ b/src/FinancialData/Entities/EtfQuotes.cs
@@ -6,7 +6,6 @@ namespace Tudormobile.FinancialData.Entities;
 /// </summary>
 public record EtfQuotes
 {
-    // TODO: Define properties based on API response or JSON sample
     /// <summary>
     /// Gets or sets the trading symbol of the ETF.
     /// </summary>

--- a/src/FinancialData/Entities/EtfQuotes.cs
+++ b/src/FinancialData/Entities/EtfQuotes.cs
@@ -7,34 +7,34 @@ namespace Tudormobile.FinancialData.Entities;
 public record EtfQuotes
 {
     /// <summary>
-    /// Gets or sets the trading symbol of the ETF.
+    /// Gets the trading symbol of the ETF.
     /// </summary>
     public string? TradingSymbol { get; init; }
 
     /// <summary>
-    /// Gets or sets the description of the ETF.
+    /// Gets the description of the ETF.
     /// </summary>
     public string? Description { get; init; }
 
     /// <summary>
-    /// Gets or sets the time of the quote.
+    /// Gets the time of the quote.
     /// </summary>
     public DateTime? Time { get; init; }
 
     /// <summary>
-    /// Gets or sets the current price of the ETF.
+    /// Gets the current price of the ETF.
     /// </summary>
-    public decimal? Price { get; init; }
+    public decimal Price { get; init; }
 
     /// <summary>
-    /// Gets or sets the price change.
+    /// Gets the price change.
     /// </summary>
-    public decimal? Change { get; init; }
+    public decimal Change { get; init; }
 
     /// <summary>
-    /// Gets or sets the percentage change in price.
+    /// Gets the percentage change in price.
     /// </summary>
-    public decimal? PercentageChange { get; init; }
+    public decimal PercentageChange { get; init; }
 }
 /* ref: https://financialdata.net/documentation#ETF_quotes
 {

--- a/src/FinancialData/Entities/ExecutiveCompensation.cs
+++ b/src/FinancialData/Entities/ExecutiveCompensation.cs
@@ -27,9 +27,9 @@ public record ExecutiveCompensation
     public string? ExecutiveName { get; init; }
 
     /// <summary>
-    /// Gets or sets the position of the executive.
+    /// Gets or sets the position or title of the executive.
     /// </summary>
-    public string? ExecutivePosition { get; init; }
+    public string? ExecutiveTitle { get; init; }
 
     /// <summary>
     /// Gets or sets the fiscal year.
@@ -52,17 +52,40 @@ public record ExecutiveCompensation
     public decimal StockAwards { get; init; }
 
     /// <summary>
-    /// Gets or sets the incentive plan compensation.
+    /// Gets or sets the value of option awards.
     /// </summary>
-    public decimal IncentivePlanCompensation { get; init; }
+    public decimal OptionAwards { get; init; }
 
     /// <summary>
-    /// Gets or sets other compensation.
+    /// Gets or sets the non-equity incentive plan compensation.
     /// </summary>
-    public decimal OtherCompensation { get; init; }
+    public decimal NonEquityIncentivePlanCompensation { get; init; }
+
+    /// <summary>
+    /// Gets or sets all other compensation.
+    /// </summary>
+    public decimal AllOtherCompensation { get; init; }
 
     /// <summary>
     /// Gets or sets the total compensation.
     /// </summary>
     public decimal TotalCompensation { get; init; }
 }
+/* ref: https://financialdata.net/documentation#executive_compensation
+{
+    "trading_symbol": "AAPL",
+    "central_index_key": "0000320193",
+    "registrant_name": "Apple Inc.",
+    "fiscal_year": "2023",
+    "executive_name": "Tim Cook",
+    "executive_title": "CEO",
+    "salary": 3000000.0,
+    "bonus": 12000000.0,
+    "stock_awards": 82000000.0,
+    "option_awards": 0.0,
+    "non_equity_incentive_plan_compensation": 10000000.0,
+    "all_other_compensation": 1500000.0,
+    "total_compensation": 108500000.0
+}
+*/
+

--- a/src/FinancialData/Entities/ExecutiveCompensation.cs
+++ b/src/FinancialData/Entities/ExecutiveCompensation.cs
@@ -7,67 +7,67 @@ namespace Tudormobile.FinancialData.Entities;
 public record ExecutiveCompensation
 {
     /// <summary>
-    /// Gets or sets the trading symbol of the company.
+    /// Gets the trading symbol of the company.
     /// </summary>
     public string? TradingSymbol { get; init; }
 
     /// <summary>
-    /// Gets or sets the central index key (CIK) assigned by the SEC.
+    /// Gets the central index key (CIK) assigned by the SEC.
     /// </summary>
     public string? CentralIndexKey { get; init; }
 
     /// <summary>
-    /// Gets or sets the registrant name of the company.
+    /// Gets the registrant name of the company.
     /// </summary>
     public string? RegistrantName { get; init; }
 
     /// <summary>
-    /// Gets or sets the name of the executive.
+    /// Gets the name of the executive.
     /// </summary>
     public string? ExecutiveName { get; init; }
 
     /// <summary>
-    /// Gets or sets the position or title of the executive.
+    /// Gets the position or title of the executive.
     /// </summary>
     public string? ExecutiveTitle { get; init; }
 
     /// <summary>
-    /// Gets or sets the fiscal year.
+    /// Gets the fiscal year.
     /// </summary>
     public string? FiscalYear { get; init; }
 
     /// <summary>
-    /// Gets or sets the base salary.
+    /// Gets the base salary.
     /// </summary>
     public decimal Salary { get; init; }
 
     /// <summary>
-    /// Gets or sets the bonus amount.
+    /// Gets the bonus amount.
     /// </summary>
     public decimal Bonus { get; init; }
 
     /// <summary>
-    /// Gets or sets the value of stock awards.
+    /// Gets the value of stock awards.
     /// </summary>
     public decimal StockAwards { get; init; }
 
     /// <summary>
-    /// Gets or sets the value of option awards.
+    /// Gets the value of option awards.
     /// </summary>
     public decimal OptionAwards { get; init; }
 
     /// <summary>
-    /// Gets or sets the non-equity incentive plan compensation.
+    /// Gets the non-equity incentive plan compensation.
     /// </summary>
     public decimal NonEquityIncentivePlanCompensation { get; init; }
 
     /// <summary>
-    /// Gets or sets all other compensation.
+    /// Gets all other compensation.
     /// </summary>
     public decimal AllOtherCompensation { get; init; }
 
     /// <summary>
-    /// Gets or sets the total compensation.
+    /// Gets the total compensation.
     /// </summary>
     public decimal TotalCompensation { get; init; }
 }

--- a/src/FinancialData/Entities/ExecutiveCompensation.cs
+++ b/src/FinancialData/Entities/ExecutiveCompensation.cs
@@ -1,0 +1,68 @@
+namespace Tudormobile.FinancialData.Entities;
+
+/// <summary>
+/// Represents executive compensation data including salary, bonus, stock awards, and total compensation.
+/// <para>See: https://financialdata.net/documentation#executive_compensation</para>
+/// </summary>
+public record ExecutiveCompensation
+{
+    /// <summary>
+    /// Gets or sets the trading symbol of the company.
+    /// </summary>
+    public string? TradingSymbol { get; init; }
+
+    /// <summary>
+    /// Gets or sets the central index key (CIK) assigned by the SEC.
+    /// </summary>
+    public string? CentralIndexKey { get; init; }
+
+    /// <summary>
+    /// Gets or sets the registrant name of the company.
+    /// </summary>
+    public string? RegistrantName { get; init; }
+
+    /// <summary>
+    /// Gets or sets the name of the executive.
+    /// </summary>
+    public string? ExecutiveName { get; init; }
+
+    /// <summary>
+    /// Gets or sets the position of the executive.
+    /// </summary>
+    public string? ExecutivePosition { get; init; }
+
+    /// <summary>
+    /// Gets or sets the fiscal year.
+    /// </summary>
+    public string? FiscalYear { get; init; }
+
+    /// <summary>
+    /// Gets or sets the base salary.
+    /// </summary>
+    public decimal Salary { get; init; }
+
+    /// <summary>
+    /// Gets or sets the bonus amount.
+    /// </summary>
+    public decimal Bonus { get; init; }
+
+    /// <summary>
+    /// Gets or sets the value of stock awards.
+    /// </summary>
+    public decimal StockAwards { get; init; }
+
+    /// <summary>
+    /// Gets or sets the incentive plan compensation.
+    /// </summary>
+    public decimal IncentivePlanCompensation { get; init; }
+
+    /// <summary>
+    /// Gets or sets other compensation.
+    /// </summary>
+    public decimal OtherCompensation { get; init; }
+
+    /// <summary>
+    /// Gets or sets the total compensation.
+    /// </summary>
+    public decimal TotalCompensation { get; init; }
+}

--- a/src/FinancialData/Entities/FedPressRelease.cs
+++ b/src/FinancialData/Entities/FedPressRelease.cs
@@ -7,22 +7,22 @@ namespace Tudormobile.FinancialData.Entities;
 public record FedPressRelease
 {
     /// <summary>
-    /// Gets or sets the date and time of the Federal Reserve press release.
+    /// Gets the date and time of the Federal Reserve press release.
     /// </summary>
     public DateTime DateTime { get; init; }
 
     /// <summary>
-    /// Gets or sets the headline of the press release.
+    /// Gets the headline of the press release.
     /// </summary>
     public string? Headline { get; init; }
 
     /// <summary>
-    /// Gets or sets the full text content of the press release.
+    /// Gets the full text content of the press release.
     /// </summary>
     public string? Text { get; init; }
 
     /// <summary>
-    /// Gets or sets the URL to the press release.
+    /// Gets the URL to the press release.
     /// </summary>
     public string? Url { get; init; }
 }

--- a/src/FinancialData/Entities/FedPressRelease.cs
+++ b/src/FinancialData/Entities/FedPressRelease.cs
@@ -1,0 +1,28 @@
+namespace Tudormobile.FinancialData.Entities;
+
+/// <summary>
+/// Represents a Federal Reserve press release with headline, date, and content.
+/// <para>See: https://financialdata.net/documentation#fed_press_releases</para>
+/// </summary>
+public record FedPressRelease
+{
+    /// <summary>
+    /// Gets or sets the date and time of the Federal Reserve press release.
+    /// </summary>
+    public DateTime DateTime { get; init; }
+
+    /// <summary>
+    /// Gets or sets the headline of the press release.
+    /// </summary>
+    public string? Headline { get; init; }
+
+    /// <summary>
+    /// Gets or sets the full text content of the press release.
+    /// </summary>
+    public string? Text { get; init; }
+
+    /// <summary>
+    /// Gets or sets the URL to the press release.
+    /// </summary>
+    public string? Url { get; init; }
+}

--- a/src/FinancialData/Entities/ForexMinutePrice.cs
+++ b/src/FinancialData/Entities/ForexMinutePrice.cs
@@ -7,32 +7,32 @@ namespace Tudormobile.FinancialData.Entities;
 public record ForexMinutePrice
 {
     /// <summary>
-    /// Gets or sets the trading symbol of the forex pair.
+    /// Gets the trading symbol of the forex pair.
     /// </summary>
     public string? TradingSymbol { get; init; }
 
     /// <summary>
-    /// Gets or sets the timestamp of the minute price record (UTC).
+    /// Gets the timestamp of the minute price record (UTC).
     /// </summary>
     public DateTime Time { get; init; }
 
     /// <summary>
-    /// Gets or sets the opening rate for the one-minute period.
+    /// Gets the opening rate for the one-minute period.
     /// </summary>
     public decimal Open { get; init; }
 
     /// <summary>
-    /// Gets or sets the highest rate during the one-minute period.
+    /// Gets the highest rate during the one-minute period.
     /// </summary>
     public decimal High { get; init; }
 
     /// <summary>
-    /// Gets or sets the lowest rate during the one-minute period.
+    /// Gets the lowest rate during the one-minute period.
     /// </summary>
     public decimal Low { get; init; }
 
     /// <summary>
-    /// Gets or sets the closing rate for the one-minute period.
+    /// Gets the closing rate for the one-minute period.
     /// </summary>
     public decimal Close { get; init; }
 }

--- a/src/FinancialData/Entities/ForexMinutePrice.cs
+++ b/src/FinancialData/Entities/ForexMinutePrice.cs
@@ -1,0 +1,38 @@
+namespace Tudormobile.FinancialData.Entities;
+
+/// <summary>
+/// Represents one-minute historical price data for a forex currency pair.
+/// <para>See: https://financialdata.net/documentation#forex_minute_prices</para>
+/// </summary>
+public record ForexMinutePrice
+{
+    /// <summary>
+    /// Gets or sets the trading symbol of the forex pair.
+    /// </summary>
+    public string? TradingSymbol { get; init; }
+
+    /// <summary>
+    /// Gets or sets the timestamp of the minute price record (UTC).
+    /// </summary>
+    public DateTime Time { get; init; }
+
+    /// <summary>
+    /// Gets or sets the opening rate for the one-minute period.
+    /// </summary>
+    public decimal Open { get; init; }
+
+    /// <summary>
+    /// Gets or sets the highest rate during the one-minute period.
+    /// </summary>
+    public decimal High { get; init; }
+
+    /// <summary>
+    /// Gets or sets the lowest rate during the one-minute period.
+    /// </summary>
+    public decimal Low { get; init; }
+
+    /// <summary>
+    /// Gets or sets the closing rate for the one-minute period.
+    /// </summary>
+    public decimal Close { get; init; }
+}

--- a/src/FinancialData/Entities/ForexPrice.cs
+++ b/src/FinancialData/Entities/ForexPrice.cs
@@ -1,0 +1,38 @@
+namespace Tudormobile.FinancialData.Entities;
+
+/// <summary>
+/// Represents daily historical price data for a forex currency pair.
+/// <para>See: https://financialdata.net/documentation#forex_prices</para>
+/// </summary>
+public record ForexPrice
+{
+    /// <summary>
+    /// Gets or sets the trading symbol of the forex pair.
+    /// </summary>
+    public string? TradingSymbol { get; init; }
+
+    /// <summary>
+    /// Gets or sets the date of the price record.
+    /// </summary>
+    public DateOnly Date { get; init; }
+
+    /// <summary>
+    /// Gets or sets the opening rate.
+    /// </summary>
+    public decimal Open { get; init; }
+
+    /// <summary>
+    /// Gets or sets the highest rate.
+    /// </summary>
+    public decimal High { get; init; }
+
+    /// <summary>
+    /// Gets or sets the lowest rate.
+    /// </summary>
+    public decimal Low { get; init; }
+
+    /// <summary>
+    /// Gets or sets the closing rate.
+    /// </summary>
+    public decimal Close { get; init; }
+}

--- a/src/FinancialData/Entities/ForexPrice.cs
+++ b/src/FinancialData/Entities/ForexPrice.cs
@@ -7,32 +7,32 @@ namespace Tudormobile.FinancialData.Entities;
 public record ForexPrice
 {
     /// <summary>
-    /// Gets or sets the trading symbol of the forex pair.
+    /// Gets the trading symbol of the forex pair.
     /// </summary>
     public string? TradingSymbol { get; init; }
 
     /// <summary>
-    /// Gets or sets the date of the price record.
+    /// Gets the date of the price record.
     /// </summary>
     public DateOnly Date { get; init; }
 
     /// <summary>
-    /// Gets or sets the opening rate.
+    /// Gets the opening rate.
     /// </summary>
     public decimal Open { get; init; }
 
     /// <summary>
-    /// Gets or sets the highest rate.
+    /// Gets the highest rate.
     /// </summary>
     public decimal High { get; init; }
 
     /// <summary>
-    /// Gets or sets the lowest rate.
+    /// Gets the lowest rate.
     /// </summary>
     public decimal Low { get; init; }
 
     /// <summary>
-    /// Gets or sets the closing rate.
+    /// Gets the closing rate.
     /// </summary>
     public decimal Close { get; init; }
 }

--- a/src/FinancialData/Entities/ForexQuote.cs
+++ b/src/FinancialData/Entities/ForexQuote.cs
@@ -1,0 +1,33 @@
+namespace Tudormobile.FinancialData.Entities;
+
+/// <summary>
+/// Represents real-time quote data for a forex currency pair.
+/// <para>See: https://financialdata.net/documentation#forex_quotes</para>
+/// </summary>
+public record ForexQuote
+{
+    /// <summary>
+    /// Gets or sets the trading symbol of the forex pair.
+    /// </summary>
+    public string? TradingSymbol { get; init; }
+
+    /// <summary>
+    /// Gets or sets the timestamp of the quote (UTC).
+    /// </summary>
+    public DateTime Time { get; init; }
+
+    /// <summary>
+    /// Gets or sets the bid price.
+    /// </summary>
+    public decimal Bid { get; init; }
+
+    /// <summary>
+    /// Gets or sets the ask price.
+    /// </summary>
+    public decimal Ask { get; init; }
+
+    /// <summary>
+    /// Gets or sets the current exchange rate.
+    /// </summary>
+    public decimal Rate { get; init; }
+}

--- a/src/FinancialData/Entities/ForexQuote.cs
+++ b/src/FinancialData/Entities/ForexQuote.cs
@@ -7,27 +7,27 @@ namespace Tudormobile.FinancialData.Entities;
 public record ForexQuote
 {
     /// <summary>
-    /// Gets or sets the trading symbol of the forex pair.
+    /// Gets the trading symbol of the forex pair.
     /// </summary>
     public string? TradingSymbol { get; init; }
 
     /// <summary>
-    /// Gets or sets the timestamp of the quote (UTC).
+    /// Gets the timestamp of the quote (UTC).
     /// </summary>
     public DateTime Time { get; init; }
 
     /// <summary>
-    /// Gets or sets the bid price.
+    /// Gets the bid price.
     /// </summary>
     public decimal Bid { get; init; }
 
     /// <summary>
-    /// Gets or sets the ask price.
+    /// Gets the ask price.
     /// </summary>
     public decimal Ask { get; init; }
 
     /// <summary>
-    /// Gets or sets the current exchange rate.
+    /// Gets the current exchange rate.
     /// </summary>
     public decimal Rate { get; init; }
 }

--- a/src/FinancialData/Entities/ForexSymbol.cs
+++ b/src/FinancialData/Entities/ForexSymbol.cs
@@ -1,0 +1,18 @@
+namespace Tudormobile.FinancialData.Entities;
+
+/// <summary>
+/// Represents a forex currency pair symbol.
+/// <para>See: https://financialdata.net/documentation#forex_symbols</para>
+/// </summary>
+public record ForexSymbol
+{
+    /// <summary>
+    /// Gets or sets the trading symbol of the forex pair.
+    /// </summary>
+    public string? TradingSymbol { get; init; }
+
+    /// <summary>
+    /// Gets or sets the full name of the forex pair.
+    /// </summary>
+    public string? Name { get; init; }
+}

--- a/src/FinancialData/Entities/ForexSymbol.cs
+++ b/src/FinancialData/Entities/ForexSymbol.cs
@@ -7,12 +7,12 @@ namespace Tudormobile.FinancialData.Entities;
 public record ForexSymbol
 {
     /// <summary>
-    /// Gets or sets the trading symbol of the forex pair.
+    /// Gets the trading symbol of the forex pair.
     /// </summary>
     public string? TradingSymbol { get; init; }
 
     /// <summary>
-    /// Gets or sets the full name of the forex pair.
+    /// Gets the full name of the forex pair.
     /// </summary>
     public string? Name { get; init; }
 }

--- a/src/FinancialData/Entities/FuturesPrice.cs
+++ b/src/FinancialData/Entities/FuturesPrice.cs
@@ -1,0 +1,43 @@
+namespace Tudormobile.FinancialData.Entities;
+
+/// <summary>
+/// Represents daily historical futures price data including open, high, low, close, and volume.
+/// <para>See: https://financialdata.net/documentation#futures_prices</para>
+/// </summary>
+public record FuturesPrice
+{
+    /// <summary>
+    /// Gets or sets the trading symbol of the futures contract.
+    /// </summary>
+    public string? TradingSymbol { get; init; }
+
+    /// <summary>
+    /// Gets or sets the date of the price record.
+    /// </summary>
+    public DateOnly Date { get; init; }
+
+    /// <summary>
+    /// Gets or sets the opening price.
+    /// </summary>
+    public decimal Open { get; init; }
+
+    /// <summary>
+    /// Gets or sets the highest price.
+    /// </summary>
+    public decimal High { get; init; }
+
+    /// <summary>
+    /// Gets or sets the lowest price.
+    /// </summary>
+    public decimal Low { get; init; }
+
+    /// <summary>
+    /// Gets or sets the closing price.
+    /// </summary>
+    public decimal Close { get; init; }
+
+    /// <summary>
+    /// Gets or sets the trading volume.
+    /// </summary>
+    public decimal Volume { get; init; }
+}

--- a/src/FinancialData/Entities/FuturesPrice.cs
+++ b/src/FinancialData/Entities/FuturesPrice.cs
@@ -7,37 +7,37 @@ namespace Tudormobile.FinancialData.Entities;
 public record FuturesPrice
 {
     /// <summary>
-    /// Gets or sets the trading symbol of the futures contract.
+    /// Gets the trading symbol of the futures contract.
     /// </summary>
     public string? TradingSymbol { get; init; }
 
     /// <summary>
-    /// Gets or sets the date of the price record.
+    /// Gets the date of the price record.
     /// </summary>
     public DateOnly Date { get; init; }
 
     /// <summary>
-    /// Gets or sets the opening price.
+    /// Gets the opening price.
     /// </summary>
     public decimal Open { get; init; }
 
     /// <summary>
-    /// Gets or sets the highest price.
+    /// Gets the highest price.
     /// </summary>
     public decimal High { get; init; }
 
     /// <summary>
-    /// Gets or sets the lowest price.
+    /// Gets the lowest price.
     /// </summary>
     public decimal Low { get; init; }
 
     /// <summary>
-    /// Gets or sets the closing price.
+    /// Gets the closing price.
     /// </summary>
     public decimal Close { get; init; }
 
     /// <summary>
-    /// Gets or sets the trading volume.
+    /// Gets the trading volume.
     /// </summary>
     public decimal Volume { get; init; }
 }

--- a/src/FinancialData/Entities/FuturesSymbol.cs
+++ b/src/FinancialData/Entities/FuturesSymbol.cs
@@ -7,17 +7,17 @@ namespace Tudormobile.FinancialData.Entities;
 public record FuturesSymbol
 {
     /// <summary>
-    /// Gets or sets the trading symbol of the futures contract.
+    /// Gets the trading symbol of the futures contract.
     /// </summary>
     public string? TradingSymbol { get; init; }
 
     /// <summary>
-    /// Gets or sets the description of the futures contract.
+    /// Gets the description of the futures contract.
     /// </summary>
     public string? Description { get; init; }
 
     /// <summary>
-    /// Gets or sets the type of futures contract (e.g., Interest Rates, Metals, Equities).
+    /// Gets the type of futures contract (e.g., Interest Rates, Metals, Equities).
     /// </summary>
     public string? Type { get; init; }
 }

--- a/src/FinancialData/Entities/FuturesSymbol.cs
+++ b/src/FinancialData/Entities/FuturesSymbol.cs
@@ -1,0 +1,23 @@
+namespace Tudormobile.FinancialData.Entities;
+
+/// <summary>
+/// Represents a futures contract symbol and its description and type.
+/// <para>See: https://financialdata.net/documentation#futures_symbols</para>
+/// </summary>
+public record FuturesSymbol
+{
+    /// <summary>
+    /// Gets or sets the trading symbol of the futures contract.
+    /// </summary>
+    public string? TradingSymbol { get; init; }
+
+    /// <summary>
+    /// Gets or sets the description of the futures contract.
+    /// </summary>
+    public string? Description { get; init; }
+
+    /// <summary>
+    /// Gets or sets the type of futures contract (e.g., Interest Rates, Metals, Equities).
+    /// </summary>
+    public string? Type { get; init; }
+}

--- a/src/FinancialData/Entities/HouseTrading.cs
+++ b/src/FinancialData/Entities/HouseTrading.cs
@@ -7,42 +7,42 @@ namespace Tudormobile.FinancialData.Entities;
 public record HouseTrading
 {
     /// <summary>
-    /// Gets or sets the trading symbol of the company.
+    /// Gets the trading symbol of the company.
     /// </summary>
     public string? TradingSymbol { get; init; }
 
     /// <summary>
-    /// Gets or sets the name of the House member.
+    /// Gets the name of the House member.
     /// </summary>
     public string? RepresentativeName { get; init; }
 
     /// <summary>
-    /// Gets or sets the date of the transaction.
+    /// Gets the date of the transaction.
     /// </summary>
     public DateOnly TransactionDate { get; init; }
 
     /// <summary>
-    /// Gets or sets the disclosure date.
+    /// Gets the disclosure date.
     /// </summary>
     public DateOnly DisclosureDate { get; init; }
 
     /// <summary>
-    /// Gets or sets the transaction type (e.g., Purchase, Sale).
+    /// Gets the transaction type (e.g., Purchase, Sale).
     /// </summary>
     public string? TransactionType { get; init; }
 
     /// <summary>
-    /// Gets or sets the asset type (e.g., Stock, Stock Option).
+    /// Gets the asset type (e.g., Stock, Stock Option).
     /// </summary>
     public string? AssetType { get; init; }
 
     /// <summary>
-    /// Gets or sets the amount range of the transaction.
+    /// Gets the amount range of the transaction.
     /// </summary>
     public string? AmountRange { get; init; }
 
     /// <summary>
-    /// Gets or sets additional comments.
+    /// Gets additional comments.
     /// </summary>
     public string? Comment { get; init; }
 }

--- a/src/FinancialData/Entities/HouseTrading.cs
+++ b/src/FinancialData/Entities/HouseTrading.cs
@@ -1,0 +1,48 @@
+namespace Tudormobile.FinancialData.Entities;
+
+/// <summary>
+/// Represents a stock transaction by a U.S. House of Representatives member.
+/// <para>See: https://financialdata.net/documentation#house_trading</para>
+/// </summary>
+public record HouseTrading
+{
+    /// <summary>
+    /// Gets or sets the trading symbol of the company.
+    /// </summary>
+    public string? TradingSymbol { get; init; }
+
+    /// <summary>
+    /// Gets or sets the name of the House member.
+    /// </summary>
+    public string? RepresentativeName { get; init; }
+
+    /// <summary>
+    /// Gets or sets the date of the transaction.
+    /// </summary>
+    public DateOnly TransactionDate { get; init; }
+
+    /// <summary>
+    /// Gets or sets the disclosure date.
+    /// </summary>
+    public DateOnly DisclosureDate { get; init; }
+
+    /// <summary>
+    /// Gets or sets the transaction type (e.g., Purchase, Sale).
+    /// </summary>
+    public string? TransactionType { get; init; }
+
+    /// <summary>
+    /// Gets or sets the asset type (e.g., Stock, Stock Option).
+    /// </summary>
+    public string? AssetType { get; init; }
+
+    /// <summary>
+    /// Gets or sets the amount range of the transaction.
+    /// </summary>
+    public string? AmountRange { get; init; }
+
+    /// <summary>
+    /// Gets or sets additional comments.
+    /// </summary>
+    public string? Comment { get; init; }
+}

--- a/src/FinancialData/Entities/IndexConstituent.cs
+++ b/src/FinancialData/Entities/IndexConstituent.cs
@@ -1,0 +1,54 @@
+namespace Tudormobile.FinancialData.Entities;
+
+/// <summary>
+/// Represents a constituent of a market index, including its symbol, name, sector, and industry.
+/// <para>See: https://financialdata.net/documentation#index_constituents</para>
+/// </summary>
+public record IndexConstituent
+{
+    /// <summary>
+    /// Gets or sets the trading symbol of the market index.
+    /// </summary>
+    public string? TradingSymbol { get; init; }
+
+    /// <summary>
+    /// Gets or sets the name of the market index.
+    /// </summary>
+    public string? IndexName { get; init; }
+
+    /// <summary>
+    /// Gets or sets the symbol of the constituent security.
+    /// </summary>
+    public string? ConstituentSymbol { get; init; }
+
+    /// <summary>
+    /// Gets or sets the name of the constituent security.
+    /// </summary>
+    public string? ConstituentName { get; init; }
+
+    /// <summary>
+    /// Gets or sets the sector of the constituent security.
+    /// </summary>
+    public string? Sector { get; init; }
+
+    /// <summary>
+    /// Gets or sets the industry of the constituent security.
+    /// </summary>
+    public string? Industry { get; init; }
+
+    /// <summary>
+    /// Gets or sets the date the constituent was added to the index.
+    /// </summary>
+    public DateOnly? DateAdded { get; init; }
+}
+/*Ref: https://financialdata.net/documentation#index_constituents
+{
+    "trading_symbol": "^GSPC",
+    "index_name": "S&P 500",
+    "constituent_symbol": "COIN",
+    "constituent_name": "Coinbase",
+    "sector": "Financials",
+    "industry": "Financial Exchanges & Data",
+    "date_added": "2025-05-19"
+  }
+*/

--- a/src/FinancialData/Entities/IndexConstituent.cs
+++ b/src/FinancialData/Entities/IndexConstituent.cs
@@ -7,37 +7,37 @@ namespace Tudormobile.FinancialData.Entities;
 public record IndexConstituent
 {
     /// <summary>
-    /// Gets or sets the trading symbol of the market index.
+    /// Gets the trading symbol of the market index.
     /// </summary>
     public string? TradingSymbol { get; init; }
 
     /// <summary>
-    /// Gets or sets the name of the market index.
+    /// Gets the name of the market index.
     /// </summary>
     public string? IndexName { get; init; }
 
     /// <summary>
-    /// Gets or sets the symbol of the constituent security.
+    /// Gets the symbol of the constituent security.
     /// </summary>
     public string? ConstituentSymbol { get; init; }
 
     /// <summary>
-    /// Gets or sets the name of the constituent security.
+    /// Gets the name of the constituent security.
     /// </summary>
     public string? ConstituentName { get; init; }
 
     /// <summary>
-    /// Gets or sets the sector of the constituent security.
+    /// Gets the sector of the constituent security.
     /// </summary>
     public string? Sector { get; init; }
 
     /// <summary>
-    /// Gets or sets the industry of the constituent security.
+    /// Gets the industry of the constituent security.
     /// </summary>
     public string? Industry { get; init; }
 
     /// <summary>
-    /// Gets or sets the date the constituent was added to the index.
+    /// Gets the date the constituent was added to the index.
     /// </summary>
     public DateOnly? DateAdded { get; init; }
 }

--- a/src/FinancialData/Entities/IndexPrice.cs
+++ b/src/FinancialData/Entities/IndexPrice.cs
@@ -7,39 +7,39 @@ namespace Tudormobile.FinancialData.Entities;
 public record IndexPrice
 {
     /// <summary>
-    /// Gets or sets the trading symbol of the market index.
+    /// Gets the trading symbol of the market index.
     /// </summary>
     public string? TradingSymbol { get; init; }
 
     /// <summary>
-    /// Gets or sets the date of the price record.
+    /// Gets the date of the price record.
     /// </summary>
     public DateOnly? Date { get; init; }
 
     /// <summary>
-    /// Gets or sets the opening price of the index for the trading period.
+    /// Gets the opening price of the index for the trading period.
     /// </summary>
-    public decimal? Open { get; init; }
+    public decimal Open { get; init; }
 
     /// <summary>
-    /// Gets or sets the highest price recorded during the trading period.
+    /// Gets the highest price recorded during the trading period.
     /// </summary>
-    public decimal? High { get; init; }
+    public decimal High { get; init; }
 
     /// <summary>
-    /// Gets or sets the lowest price recorded during the trading period.
+    /// Gets the lowest price recorded during the trading period.
     /// </summary>
-    public decimal? Low { get; init; }
+    public decimal Low { get; init; }
 
     /// <summary>
-    /// Gets or sets the closing price of the index for the trading period.
+    /// Gets the closing price of the index for the trading period.
     /// </summary>
-    public decimal? Close { get; init; }
+    public decimal Close { get; init; }
 
     /// <summary>
-    /// Gets or sets the total traded volume for the index.
+    /// Gets the total traded volume for the index.
     /// </summary>
-    public decimal? Volume { get; init; }
+    public decimal Volume { get; init; }
 }
 /* ref: https://financialdata.net/documentation#index_prices
 {

--- a/src/FinancialData/Entities/IndexPrice.cs
+++ b/src/FinancialData/Entities/IndexPrice.cs
@@ -1,0 +1,54 @@
+namespace Tudormobile.FinancialData.Entities;
+
+/// <summary>
+/// Represents daily price information for a market index, including open, high, low, close, and volume.
+/// <para>See: https://financialdata.net/documentation#index_prices</para>
+/// </summary>
+public record IndexPrice
+{
+    /// <summary>
+    /// Gets or sets the trading symbol of the market index.
+    /// </summary>
+    public string? TradingSymbol { get; init; }
+
+    /// <summary>
+    /// Gets or sets the date of the price record.
+    /// </summary>
+    public DateOnly? Date { get; init; }
+
+    /// <summary>
+    /// Gets or sets the opening price of the index for the trading period.
+    /// </summary>
+    public decimal? Open { get; init; }
+
+    /// <summary>
+    /// Gets or sets the highest price recorded during the trading period.
+    /// </summary>
+    public decimal? High { get; init; }
+
+    /// <summary>
+    /// Gets or sets the lowest price recorded during the trading period.
+    /// </summary>
+    public decimal? Low { get; init; }
+
+    /// <summary>
+    /// Gets or sets the closing price of the index for the trading period.
+    /// </summary>
+    public decimal? Close { get; init; }
+
+    /// <summary>
+    /// Gets or sets the total traded volume for the index.
+    /// </summary>
+    public decimal? Volume { get; init; }
+}
+/* ref: https://financialdata.net/documentation#index_prices
+{
+    "trading_symbol": "^GSPC",
+    "date": "2025-06-13",
+    "open": 6000.56,
+    "high": 6026.16,
+    "low": 5963.21,
+    "close": 5976.97,
+    "volume": 5258910000.0
+  }
+*/

--- a/src/FinancialData/Entities/IndexQuote.cs
+++ b/src/FinancialData/Entities/IndexQuote.cs
@@ -1,0 +1,48 @@
+namespace Tudormobile.FinancialData.Entities;
+
+/// <summary>
+/// Represents a real-time or recent quote for a market index, including price, change, and percentage change.
+/// <para>See: https://financialdata.net/documentation#index_quotes</para>
+/// </summary>
+public record IndexQuote
+{
+    /// <summary>
+    /// Gets or sets the trading symbol of the market index.
+    /// </summary>
+    public string? TradingSymbol { get; init; }
+
+    /// <summary>
+    /// Gets or sets the name of the market index.
+    /// </summary>
+    public string? IndexName { get; init; }
+
+    /// <summary>
+    /// Gets or sets the time of the quote.
+    /// </summary>
+    public DateTime? Time { get; init; }
+
+    /// <summary>
+    /// Gets or sets the current price of the index.
+    /// </summary>
+    public decimal? Price { get; init; }
+
+    /// <summary>
+    /// Gets or sets the price change.
+    /// </summary>
+    public decimal? Change { get; init; }
+
+    /// <summary>
+    /// Gets or sets the percentage change in price.
+    /// </summary>
+    public decimal? PercentageChange { get; init; }
+}
+/* ref: https://financialdata.net/documentation#index_quotes
+{
+    "trading_symbol": "^GSPC",
+    "index_name": "S&P 500",
+    "time": "2025-09-23 15:19:59",
+    "price": 6656.92,
+    "change": -36.83,
+    "percentage_change": -0.55
+  }
+*/

--- a/src/FinancialData/Entities/IndexQuote.cs
+++ b/src/FinancialData/Entities/IndexQuote.cs
@@ -7,34 +7,34 @@ namespace Tudormobile.FinancialData.Entities;
 public record IndexQuote
 {
     /// <summary>
-    /// Gets or sets the trading symbol of the market index.
+    /// Gets the trading symbol of the market index.
     /// </summary>
     public string? TradingSymbol { get; init; }
 
     /// <summary>
-    /// Gets or sets the name of the market index.
+    /// Gets the name of the market index.
     /// </summary>
     public string? IndexName { get; init; }
 
     /// <summary>
-    /// Gets or sets the time of the quote.
+    /// Gets the time of the quote.
     /// </summary>
     public DateTime? Time { get; init; }
 
     /// <summary>
-    /// Gets or sets the current price of the index.
+    /// Gets the current price of the index.
     /// </summary>
-    public decimal? Price { get; init; }
+    public decimal Price { get; init; }
 
     /// <summary>
-    /// Gets or sets the price change.
+    /// Gets the price change.
     /// </summary>
-    public decimal? Change { get; init; }
+    public decimal Change { get; init; }
 
     /// <summary>
-    /// Gets or sets the percentage change in price.
+    /// Gets the percentage change in price.
     /// </summary>
-    public decimal? PercentageChange { get; init; }
+    public decimal PercentageChange { get; init; }
 }
 /* ref: https://financialdata.net/documentation#index_quotes
 {

--- a/src/FinancialData/Entities/IndexSymbol.cs
+++ b/src/FinancialData/Entities/IndexSymbol.cs
@@ -1,0 +1,24 @@
+namespace Tudormobile.FinancialData.Entities;
+
+/// <summary>
+/// Represents a market index symbol, including its trading symbol and name.
+/// <para>See: https://financialdata.net/documentation#index_symbols</para>
+/// </summary>
+public record IndexSymbol
+{
+    /// <summary>
+    /// Gets or sets the trading symbol of the market index.
+    /// </summary>
+    public string? TradingSymbol { get; init; }
+
+    /// <summary>
+    /// Gets or sets the name of the market index.
+    /// </summary>
+    public string? IndexName { get; init; }
+}
+/* ref: https://financialdata.net/documentation#index_symbols
+{
+    "trading_symbol": "000001.SS",
+    "index_name": "SSE Composite Index"
+  }
+*/

--- a/src/FinancialData/Entities/IndexSymbol.cs
+++ b/src/FinancialData/Entities/IndexSymbol.cs
@@ -7,12 +7,12 @@ namespace Tudormobile.FinancialData.Entities;
 public record IndexSymbol
 {
     /// <summary>
-    /// Gets or sets the trading symbol of the market index.
+    /// Gets the trading symbol of the market index.
     /// </summary>
     public string? TradingSymbol { get; init; }
 
     /// <summary>
-    /// Gets or sets the name of the market index.
+    /// Gets the name of the market index.
     /// </summary>
     public string? IndexName { get; init; }
 }

--- a/src/FinancialData/Entities/IndustryEsgScore.cs
+++ b/src/FinancialData/Entities/IndustryEsgScore.cs
@@ -1,0 +1,48 @@
+namespace Tudormobile.FinancialData.Entities;
+
+/// <summary>
+/// Represents average ESG scores for an industry sector.
+/// <para>See: https://financialdata.net/documentation#industry_esg_scores</para>
+/// </summary>
+public record IndustryEsgScore
+{
+    /// <summary>
+    /// Gets or sets the industry name.
+    /// </summary>
+    public string? Industry { get; init; }
+
+    /// <summary>
+    /// Gets or sets the date of the industry ESG score.
+    /// </summary>
+    public DateOnly Date { get; init; }
+
+    /// <summary>
+    /// Gets or sets the average overall ESG score for the industry.
+    /// </summary>
+    public decimal AverageTotalScore { get; init; }
+
+    /// <summary>
+    /// Gets or sets the average environmental score for the industry.
+    /// </summary>
+    public decimal AverageEnvironmentalScore { get; init; }
+
+    /// <summary>
+    /// Gets or sets the average social score for the industry.
+    /// </summary>
+    public decimal AverageSocialScore { get; init; }
+
+    /// <summary>
+    /// Gets or sets the average governance score for the industry.
+    /// </summary>
+    public decimal AverageGovernanceScore { get; init; }
+
+    /// <summary>
+    /// Gets or sets the average controversy score for the industry.
+    /// </summary>
+    public decimal AverageControversyScore { get; init; }
+
+    /// <summary>
+    /// Gets or sets the number of companies in the industry sample.
+    /// </summary>
+    public int NumberOfCompanies { get; init; }
+}

--- a/src/FinancialData/Entities/IndustryEsgScore.cs
+++ b/src/FinancialData/Entities/IndustryEsgScore.cs
@@ -7,42 +7,42 @@ namespace Tudormobile.FinancialData.Entities;
 public record IndustryEsgScore
 {
     /// <summary>
-    /// Gets or sets the industry name.
+    /// Gets the industry name.
     /// </summary>
     public string? Industry { get; init; }
 
     /// <summary>
-    /// Gets or sets the date of the industry ESG score.
+    /// Gets the date of the industry ESG score.
     /// </summary>
     public DateOnly Date { get; init; }
 
     /// <summary>
-    /// Gets or sets the average overall ESG score for the industry.
+    /// Gets the average overall ESG score for the industry.
     /// </summary>
     public decimal AverageTotalScore { get; init; }
 
     /// <summary>
-    /// Gets or sets the average environmental score for the industry.
+    /// Gets the average environmental score for the industry.
     /// </summary>
     public decimal AverageEnvironmentalScore { get; init; }
 
     /// <summary>
-    /// Gets or sets the average social score for the industry.
+    /// Gets the average social score for the industry.
     /// </summary>
     public decimal AverageSocialScore { get; init; }
 
     /// <summary>
-    /// Gets or sets the average governance score for the industry.
+    /// Gets the average governance score for the industry.
     /// </summary>
     public decimal AverageGovernanceScore { get; init; }
 
     /// <summary>
-    /// Gets or sets the average controversy score for the industry.
+    /// Gets the average controversy score for the industry.
     /// </summary>
     public decimal AverageControversyScore { get; init; }
 
     /// <summary>
-    /// Gets or sets the number of companies in the industry sample.
+    /// Gets the number of companies in the industry sample.
     /// </summary>
     public int NumberOfCompanies { get; init; }
 }

--- a/src/FinancialData/Entities/InitialPublicOffering.cs
+++ b/src/FinancialData/Entities/InitialPublicOffering.cs
@@ -7,37 +7,37 @@ namespace Tudormobile.FinancialData.Entities;
 public record InitialPublicOffering
 {
     /// <summary>
-    /// Gets or sets the trading symbol of the company.
+    /// Gets the trading symbol of the company.
     /// </summary>
     public string? TradingSymbol { get; init; }
 
     /// <summary>
-    /// Gets or sets the registrant name of the company.
+    /// Gets the registrant name of the company.
     /// </summary>
     public string? RegistrantName { get; init; }
 
     /// <summary>
-    /// Gets or sets the stock exchange.
+    /// Gets the stock exchange.
     /// </summary>
     public string? Exchange { get; init; }
 
     /// <summary>
-    /// Gets or sets the pricing date of the IPO.
+    /// Gets the pricing date of the IPO.
     /// </summary>
     public DateOnly PricingDate { get; init; }
 
     /// <summary>
-    /// Gets or sets the share price.
+    /// Gets the share price.
     /// </summary>
     public decimal SharePrice { get; init; }
 
     /// <summary>
-    /// Gets or sets the number of shares offered.
+    /// Gets the number of shares offered.
     /// </summary>
     public decimal SharesOffered { get; init; }
 
     /// <summary>
-    /// Gets or sets the total offering value.
+    /// Gets the total offering value.
     /// </summary>
     public decimal OfferingValue { get; init; }
 }

--- a/src/FinancialData/Entities/InitialPublicOffering.cs
+++ b/src/FinancialData/Entities/InitialPublicOffering.cs
@@ -1,0 +1,43 @@
+namespace Tudormobile.FinancialData.Entities;
+
+/// <summary>
+/// Represents initial public offering (IPO) data including pricing date, share price, and offering value.
+/// <para>See: https://financialdata.net/documentation#initial_public_offerings</para>
+/// </summary>
+public record InitialPublicOffering
+{
+    /// <summary>
+    /// Gets or sets the trading symbol of the company.
+    /// </summary>
+    public string? TradingSymbol { get; init; }
+
+    /// <summary>
+    /// Gets or sets the registrant name of the company.
+    /// </summary>
+    public string? RegistrantName { get; init; }
+
+    /// <summary>
+    /// Gets or sets the stock exchange.
+    /// </summary>
+    public string? Exchange { get; init; }
+
+    /// <summary>
+    /// Gets or sets the pricing date of the IPO.
+    /// </summary>
+    public DateOnly PricingDate { get; init; }
+
+    /// <summary>
+    /// Gets or sets the share price.
+    /// </summary>
+    public decimal SharePrice { get; init; }
+
+    /// <summary>
+    /// Gets or sets the number of shares offered.
+    /// </summary>
+    public decimal SharesOffered { get; init; }
+
+    /// <summary>
+    /// Gets or sets the total offering value.
+    /// </summary>
+    public decimal OfferingValue { get; init; }
+}

--- a/src/FinancialData/Entities/InsiderTransaction.cs
+++ b/src/FinancialData/Entities/InsiderTransaction.cs
@@ -7,72 +7,72 @@ namespace Tudormobile.FinancialData.Entities;
 public record InsiderTransaction
 {
     /// <summary>
-    /// Gets or sets the trading symbol of the company.
+    /// Gets the trading symbol of the company.
     /// </summary>
     public string? TradingSymbol { get; init; }
 
     /// <summary>
-    /// Gets or sets the central index key (CIK) assigned by the SEC.
+    /// Gets the central index key (CIK) assigned by the SEC.
     /// </summary>
     public string? CentralIndexKey { get; init; }
 
     /// <summary>
-    /// Gets or sets the registrant name of the company.
+    /// Gets the registrant name of the company.
     /// </summary>
     public string? RegistrantName { get; init; }
 
     /// <summary>
-    /// Gets or sets the name of the insider.
+    /// Gets the name of the insider.
     /// </summary>
     public string? InsiderName { get; init; }
 
     /// <summary>
-    /// Gets or sets the title/relationship of the insider to the company.
+    /// Gets the title/relationship of the insider to the company.
     /// </summary>
     public string? InsiderTitle { get; init; }
 
     /// <summary>
-    /// Gets or sets the date of the transaction.
+    /// Gets the date of the transaction.
     /// </summary>
     public DateOnly TransactionDate { get; init; }
 
     /// <summary>
-    /// Gets or sets the filing date with the SEC.
+    /// Gets the filing date with the SEC.
     /// </summary>
     public DateOnly FilingDate { get; init; }
 
     /// <summary>
-    /// Gets or sets the transaction type (e.g., Purchase, Sale).
+    /// Gets the transaction type (e.g., Purchase, Sale).
     /// </summary>
     public string? TransactionType { get; init; }
 
     /// <summary>
-    /// Gets or sets the transaction code.
+    /// Gets the transaction code.
     /// </summary>
     public string? TransactionCode { get; init; }
 
     /// <summary>
-    /// Gets or sets the number of shares transacted.
+    /// Gets the number of shares transacted.
     /// </summary>
     public decimal Shares { get; init; }
 
     /// <summary>
-    /// Gets or sets the price per share.
+    /// Gets the price per share.
     /// </summary>
     public decimal Price { get; init; }
 
     /// <summary>
-    /// Gets or sets the total value of the transaction.
+    /// Gets the total value of the transaction.
     /// </summary>
     public decimal Value { get; init; }
 
     /// <summary>
-    /// Gets or sets the number of shares owned after the transaction.
+    /// Gets the number of shares owned after the transaction.
     /// </summary>
     public decimal SharesOwnedAfterTransaction { get; init; }
 
     /// <summary>
-    /// Gets or sets the URL to the SEC filing.
+    /// Gets the URL to the SEC filing.
     /// </summary>
     public string? SecFilingUrl { get; init; }
 }

--- a/src/FinancialData/Entities/InsiderTransaction.cs
+++ b/src/FinancialData/Entities/InsiderTransaction.cs
@@ -1,0 +1,78 @@
+namespace Tudormobile.FinancialData.Entities;
+
+/// <summary>
+/// Represents an insider trading transaction reported to the SEC.
+/// <para>See: https://financialdata.net/documentation#insider_transactions</para>
+/// </summary>
+public record InsiderTransaction
+{
+    /// <summary>
+    /// Gets or sets the trading symbol of the company.
+    /// </summary>
+    public string? TradingSymbol { get; init; }
+
+    /// <summary>
+    /// Gets or sets the central index key (CIK) assigned by the SEC.
+    /// </summary>
+    public string? CentralIndexKey { get; init; }
+
+    /// <summary>
+    /// Gets or sets the registrant name of the company.
+    /// </summary>
+    public string? RegistrantName { get; init; }
+
+    /// <summary>
+    /// Gets or sets the name of the insider.
+    /// </summary>
+    public string? InsiderName { get; init; }
+
+    /// <summary>
+    /// Gets or sets the title/relationship of the insider to the company.
+    /// </summary>
+    public string? InsiderTitle { get; init; }
+
+    /// <summary>
+    /// Gets or sets the date of the transaction.
+    /// </summary>
+    public DateOnly TransactionDate { get; init; }
+
+    /// <summary>
+    /// Gets or sets the filing date with the SEC.
+    /// </summary>
+    public DateOnly FilingDate { get; init; }
+
+    /// <summary>
+    /// Gets or sets the transaction type (e.g., Purchase, Sale).
+    /// </summary>
+    public string? TransactionType { get; init; }
+
+    /// <summary>
+    /// Gets or sets the transaction code.
+    /// </summary>
+    public string? TransactionCode { get; init; }
+
+    /// <summary>
+    /// Gets or sets the number of shares transacted.
+    /// </summary>
+    public decimal Shares { get; init; }
+
+    /// <summary>
+    /// Gets or sets the price per share.
+    /// </summary>
+    public decimal Price { get; init; }
+
+    /// <summary>
+    /// Gets or sets the total value of the transaction.
+    /// </summary>
+    public decimal Value { get; init; }
+
+    /// <summary>
+    /// Gets or sets the number of shares owned after the transaction.
+    /// </summary>
+    public decimal SharesOwnedAfterTransaction { get; init; }
+
+    /// <summary>
+    /// Gets or sets the URL to the SEC filing.
+    /// </summary>
+    public string? SecFilingUrl { get; init; }
+}

--- a/src/FinancialData/Entities/InstitutionalHolding.cs
+++ b/src/FinancialData/Entities/InstitutionalHolding.cs
@@ -7,62 +7,62 @@ namespace Tudormobile.FinancialData.Entities;
 public record InstitutionalHolding
 {
     /// <summary>
-    /// Gets or sets the trading symbol of the company.
+    /// Gets the trading symbol of the company.
     /// </summary>
     public string? TradingSymbol { get; init; }
 
     /// <summary>
-    /// Gets or sets the central index key (CIK) of the company.
+    /// Gets the central index key (CIK) of the company.
     /// </summary>
     public string? CentralIndexKey { get; init; }
 
     /// <summary>
-    /// Gets or sets the registrant name of the company.
+    /// Gets the registrant name of the company.
     /// </summary>
     public string? RegistrantName { get; init; }
 
     /// <summary>
-    /// Gets or sets the central index key (CIK) of the institutional investor.
+    /// Gets the central index key (CIK) of the institutional investor.
     /// </summary>
     public string? InvestorCik { get; init; }
 
     /// <summary>
-    /// Gets or sets the name of the institutional investor.
+    /// Gets the name of the institutional investor.
     /// </summary>
     public string? InvestorName { get; init; }
 
     /// <summary>
-    /// Gets or sets the reporting period end date.
+    /// Gets the reporting period end date.
     /// </summary>
     public DateOnly PeriodEndDate { get; init; }
 
     /// <summary>
-    /// Gets or sets the filing date with the SEC.
+    /// Gets the filing date with the SEC.
     /// </summary>
     public DateOnly FilingDate { get; init; }
 
     /// <summary>
-    /// Gets or sets the number of shares held.
+    /// Gets the number of shares held.
     /// </summary>
     public decimal Shares { get; init; }
 
     /// <summary>
-    /// Gets or sets the market value of the holding.
+    /// Gets the market value of the holding.
     /// </summary>
     public decimal Value { get; init; }
 
     /// <summary>
-    /// Gets or sets the percentage of the portfolio represented by this holding.
+    /// Gets the percentage of the portfolio represented by this holding.
     /// </summary>
     public decimal PortfolioPercent { get; init; }
 
     /// <summary>
-    /// Gets or sets the change in shares from the previous period.
+    /// Gets the change in shares from the previous period.
     /// </summary>
     public decimal SharesChange { get; init; }
 
     /// <summary>
-    /// Gets or sets the percentage change in shares.
+    /// Gets the percentage change in shares.
     /// </summary>
     public decimal SharesChangePercent { get; init; }
 }

--- a/src/FinancialData/Entities/InstitutionalHolding.cs
+++ b/src/FinancialData/Entities/InstitutionalHolding.cs
@@ -1,0 +1,68 @@
+namespace Tudormobile.FinancialData.Entities;
+
+/// <summary>
+/// Represents an institutional holding position in a company's stock.
+/// <para>See: https://financialdata.net/documentation#institutional_holdings</para>
+/// </summary>
+public record InstitutionalHolding
+{
+    /// <summary>
+    /// Gets or sets the trading symbol of the company.
+    /// </summary>
+    public string? TradingSymbol { get; init; }
+
+    /// <summary>
+    /// Gets or sets the central index key (CIK) of the company.
+    /// </summary>
+    public string? CentralIndexKey { get; init; }
+
+    /// <summary>
+    /// Gets or sets the registrant name of the company.
+    /// </summary>
+    public string? RegistrantName { get; init; }
+
+    /// <summary>
+    /// Gets or sets the central index key (CIK) of the institutional investor.
+    /// </summary>
+    public string? InvestorCik { get; init; }
+
+    /// <summary>
+    /// Gets or sets the name of the institutional investor.
+    /// </summary>
+    public string? InvestorName { get; init; }
+
+    /// <summary>
+    /// Gets or sets the reporting period end date.
+    /// </summary>
+    public DateOnly PeriodEndDate { get; init; }
+
+    /// <summary>
+    /// Gets or sets the filing date with the SEC.
+    /// </summary>
+    public DateOnly FilingDate { get; init; }
+
+    /// <summary>
+    /// Gets or sets the number of shares held.
+    /// </summary>
+    public decimal Shares { get; init; }
+
+    /// <summary>
+    /// Gets or sets the market value of the holding.
+    /// </summary>
+    public decimal Value { get; init; }
+
+    /// <summary>
+    /// Gets or sets the percentage of the portfolio represented by this holding.
+    /// </summary>
+    public decimal PortfolioPercent { get; init; }
+
+    /// <summary>
+    /// Gets or sets the change in shares from the previous period.
+    /// </summary>
+    public decimal SharesChange { get; init; }
+
+    /// <summary>
+    /// Gets or sets the percentage change in shares.
+    /// </summary>
+    public decimal SharesChangePercent { get; init; }
+}

--- a/src/FinancialData/Entities/InstitutionalInvestor.cs
+++ b/src/FinancialData/Entities/InstitutionalInvestor.cs
@@ -1,0 +1,18 @@
+namespace Tudormobile.FinancialData.Entities;
+
+/// <summary>
+/// Represents an institutional investor with name and CIK.
+/// <para>See: https://financialdata.net/documentation#institutional_investors</para>
+/// </summary>
+public record InstitutionalInvestor
+{
+    /// <summary>
+    /// Gets or sets the central index key (CIK) of the institutional investor.
+    /// </summary>
+    public string? InvestorCik { get; init; }
+
+    /// <summary>
+    /// Gets or sets the name of the institutional investor.
+    /// </summary>
+    public string? InvestorName { get; init; }
+}

--- a/src/FinancialData/Entities/InstitutionalInvestor.cs
+++ b/src/FinancialData/Entities/InstitutionalInvestor.cs
@@ -7,12 +7,12 @@ namespace Tudormobile.FinancialData.Entities;
 public record InstitutionalInvestor
 {
     /// <summary>
-    /// Gets or sets the central index key (CIK) of the institutional investor.
+    /// Gets the central index key (CIK) of the institutional investor.
     /// </summary>
     public string? InvestorCik { get; init; }
 
     /// <summary>
-    /// Gets or sets the name of the institutional investor.
+    /// Gets the name of the institutional investor.
     /// </summary>
     public string? InvestorName { get; init; }
 }

--- a/src/FinancialData/Entities/InstitutionalPortfolioStatistics.cs
+++ b/src/FinancialData/Entities/InstitutionalPortfolioStatistics.cs
@@ -7,62 +7,62 @@ namespace Tudormobile.FinancialData.Entities;
 public record InstitutionalPortfolioStatistics
 {
     /// <summary>
-    /// Gets or sets the central index key (CIK) of the institutional investor.
+    /// Gets the central index key (CIK) of the institutional investor.
     /// </summary>
     public string? InvestorCik { get; init; }
 
     /// <summary>
-    /// Gets or sets the name of the institutional investor.
+    /// Gets the name of the institutional investor.
     /// </summary>
     public string? InvestorName { get; init; }
 
     /// <summary>
-    /// Gets or sets the reporting period end date.
+    /// Gets the reporting period end date.
     /// </summary>
     public DateOnly PeriodEndDate { get; init; }
 
     /// <summary>
-    /// Gets or sets the filing date with the SEC.
+    /// Gets the filing date with the SEC.
     /// </summary>
     public DateOnly FilingDate { get; init; }
 
     /// <summary>
-    /// Gets or sets the total portfolio value.
+    /// Gets the total portfolio value.
     /// </summary>
     public decimal TotalValue { get; init; }
 
     /// <summary>
-    /// Gets or sets the number of holdings in the portfolio.
+    /// Gets the number of holdings in the portfolio.
     /// </summary>
     public int NumberOfHoldings { get; init; }
 
     /// <summary>
-    /// Gets or sets the number of new positions.
+    /// Gets the number of new positions.
     /// </summary>
     public int NewPositions { get; init; }
 
     /// <summary>
-    /// Gets or sets the number of sold out positions.
+    /// Gets the number of sold out positions.
     /// </summary>
     public int SoldOutPositions { get; init; }
 
     /// <summary>
-    /// Gets or sets the number of increased positions.
+    /// Gets the number of increased positions.
     /// </summary>
     public int IncreasedPositions { get; init; }
 
     /// <summary>
-    /// Gets or sets the number of decreased positions.
+    /// Gets the number of decreased positions.
     /// </summary>
     public int DecreasedPositions { get; init; }
 
     /// <summary>
-    /// Gets or sets the total value change from the previous period.
+    /// Gets the total value change from the previous period.
     /// </summary>
     public decimal TotalValueChange { get; init; }
 
     /// <summary>
-    /// Gets or sets the percentage change in total value.
+    /// Gets the percentage change in total value.
     /// </summary>
     public decimal TotalValueChangePercent { get; init; }
 }

--- a/src/FinancialData/Entities/InstitutionalPortfolioStatistics.cs
+++ b/src/FinancialData/Entities/InstitutionalPortfolioStatistics.cs
@@ -1,0 +1,68 @@
+namespace Tudormobile.FinancialData.Entities;
+
+/// <summary>
+/// Represents portfolio statistics for an institutional investor.
+/// <para>See: https://financialdata.net/documentation#institutional_portfolio_statistics</para>
+/// </summary>
+public record InstitutionalPortfolioStatistics
+{
+    /// <summary>
+    /// Gets or sets the central index key (CIK) of the institutional investor.
+    /// </summary>
+    public string? InvestorCik { get; init; }
+
+    /// <summary>
+    /// Gets or sets the name of the institutional investor.
+    /// </summary>
+    public string? InvestorName { get; init; }
+
+    /// <summary>
+    /// Gets or sets the reporting period end date.
+    /// </summary>
+    public DateOnly PeriodEndDate { get; init; }
+
+    /// <summary>
+    /// Gets or sets the filing date with the SEC.
+    /// </summary>
+    public DateOnly FilingDate { get; init; }
+
+    /// <summary>
+    /// Gets or sets the total portfolio value.
+    /// </summary>
+    public decimal TotalValue { get; init; }
+
+    /// <summary>
+    /// Gets or sets the number of holdings in the portfolio.
+    /// </summary>
+    public int NumberOfHoldings { get; init; }
+
+    /// <summary>
+    /// Gets or sets the number of new positions.
+    /// </summary>
+    public int NewPositions { get; init; }
+
+    /// <summary>
+    /// Gets or sets the number of sold out positions.
+    /// </summary>
+    public int SoldOutPositions { get; init; }
+
+    /// <summary>
+    /// Gets or sets the number of increased positions.
+    /// </summary>
+    public int IncreasedPositions { get; init; }
+
+    /// <summary>
+    /// Gets or sets the number of decreased positions.
+    /// </summary>
+    public int DecreasedPositions { get; init; }
+
+    /// <summary>
+    /// Gets or sets the total value change from the previous period.
+    /// </summary>
+    public decimal TotalValueChange { get; init; }
+
+    /// <summary>
+    /// Gets or sets the percentage change in total value.
+    /// </summary>
+    public decimal TotalValueChangePercent { get; init; }
+}

--- a/src/FinancialData/Entities/InternationalCompanyInformation.cs
+++ b/src/FinancialData/Entities/InternationalCompanyInformation.cs
@@ -7,52 +7,52 @@ namespace Tudormobile.FinancialData.Entities;
 public record InternationalCompanyInformation
 {
     /// <summary>
-    /// Gets or sets the trading symbol of the company.
+    /// Gets the trading symbol of the company.
     /// </summary>
     public string? TradingSymbol { get; init; }
 
     /// <summary>
-    /// Gets or sets the registrant name of the company.
+    /// Gets the registrant name of the company.
     /// </summary>
     public string? RegistrantName { get; init; }
 
     /// <summary>
-    /// Gets or sets the stock exchange where the company is listed.
+    /// Gets the stock exchange where the company is listed.
     /// </summary>
     public string? Exchange { get; init; }
 
     /// <summary>
-    /// Gets or sets the ISIN (International Securities Identification Number).
+    /// Gets the ISIN (International Securities Identification Number).
     /// </summary>
     public string? IsinNumber { get; init; }
 
     /// <summary>
-    /// Gets or sets the industry classification.
+    /// Gets the industry classification.
     /// </summary>
     public string? Industry { get; init; }
 
     /// <summary>
-    /// Gets or sets the founding date.
+    /// Gets the founding date.
     /// </summary>
     public string? FoundingDate { get; init; }
 
     /// <summary>
-    /// Gets or sets the name of the chief executive officer.
+    /// Gets the name of the chief executive officer.
     /// </summary>
     public string? ChiefExecutiveOfficer { get; init; }
 
     /// <summary>
-    /// Gets or sets the number of employees.
+    /// Gets the number of employees.
     /// </summary>
     public int NumberOfEmployees { get; init; }
 
     /// <summary>
-    /// Gets or sets the company website URL.
+    /// Gets the company website URL.
     /// </summary>
     public string? Website { get; init; }
 
     /// <summary>
-    /// Gets or sets the company description.
+    /// Gets the company description.
     /// </summary>
     public string? Description { get; init; }
 }

--- a/src/FinancialData/Entities/InternationalCompanyInformation.cs
+++ b/src/FinancialData/Entities/InternationalCompanyInformation.cs
@@ -1,0 +1,58 @@
+namespace Tudormobile.FinancialData.Entities;
+
+/// <summary>
+/// Represents basic information about an international company.
+/// <para>See: https://financialdata.net/documentation#international_company_information</para>
+/// </summary>
+public record InternationalCompanyInformation
+{
+    /// <summary>
+    /// Gets or sets the trading symbol of the company.
+    /// </summary>
+    public string? TradingSymbol { get; init; }
+
+    /// <summary>
+    /// Gets or sets the registrant name of the company.
+    /// </summary>
+    public string? RegistrantName { get; init; }
+
+    /// <summary>
+    /// Gets or sets the stock exchange where the company is listed.
+    /// </summary>
+    public string? Exchange { get; init; }
+
+    /// <summary>
+    /// Gets or sets the ISIN (International Securities Identification Number).
+    /// </summary>
+    public string? IsinNumber { get; init; }
+
+    /// <summary>
+    /// Gets or sets the industry classification.
+    /// </summary>
+    public string? Industry { get; init; }
+
+    /// <summary>
+    /// Gets or sets the founding date.
+    /// </summary>
+    public string? FoundingDate { get; init; }
+
+    /// <summary>
+    /// Gets or sets the name of the chief executive officer.
+    /// </summary>
+    public string? ChiefExecutiveOfficer { get; init; }
+
+    /// <summary>
+    /// Gets or sets the number of employees.
+    /// </summary>
+    public int NumberOfEmployees { get; init; }
+
+    /// <summary>
+    /// Gets or sets the company website URL.
+    /// </summary>
+    public string? Website { get; init; }
+
+    /// <summary>
+    /// Gets or sets the company description.
+    /// </summary>
+    public string? Description { get; init; }
+}

--- a/src/FinancialData/Entities/InternationalStockPrice.cs
+++ b/src/FinancialData/Entities/InternationalStockPrice.cs
@@ -7,37 +7,37 @@ namespace Tudormobile.FinancialData.Entities;
 public record InternationalStockPrice
 {
     /// <summary>
-    /// Gets or sets the trading symbol of the international stock.
+    /// Gets the trading symbol of the international stock.
     /// </summary>
     public string? TradingSymbol { get; init; }
 
     /// <summary>
-    /// Gets or sets the date of the price record.
+    /// Gets the date of the price record.
     /// </summary>
     public DateOnly Date { get; init; }
 
     /// <summary>
-    /// Gets or sets the opening price for the trading day.
+    /// Gets the opening price for the trading day.
     /// </summary>
     public decimal Open { get; init; }
 
     /// <summary>
-    /// Gets or sets the highest price during the trading day.
+    /// Gets the highest price during the trading day.
     /// </summary>
     public decimal High { get; init; }
 
     /// <summary>
-    /// Gets or sets the lowest price during the trading day.
+    /// Gets the lowest price during the trading day.
     /// </summary>
     public decimal Low { get; init; }
 
     /// <summary>
-    /// Gets or sets the closing price for the trading day.
+    /// Gets the closing price for the trading day.
     /// </summary>
     public decimal Close { get; init; }
 
     /// <summary>
-    /// Gets or sets the trading volume for the day.
+    /// Gets the trading volume for the day.
     /// </summary>
     public decimal Volume { get; init; }
 }

--- a/src/FinancialData/Entities/InternationalStockPrice.cs
+++ b/src/FinancialData/Entities/InternationalStockPrice.cs
@@ -1,0 +1,43 @@
+namespace Tudormobile.FinancialData.Entities;
+
+/// <summary>
+/// Represents daily historical price data for international stocks.
+/// <para>See: https://financialdata.net/documentation#international_stock_prices</para>
+/// </summary>
+public record InternationalStockPrice
+{
+    /// <summary>
+    /// Gets or sets the trading symbol of the international stock.
+    /// </summary>
+    public string? TradingSymbol { get; init; }
+
+    /// <summary>
+    /// Gets or sets the date of the price record.
+    /// </summary>
+    public DateOnly Date { get; init; }
+
+    /// <summary>
+    /// Gets or sets the opening price for the trading day.
+    /// </summary>
+    public decimal Open { get; init; }
+
+    /// <summary>
+    /// Gets or sets the highest price during the trading day.
+    /// </summary>
+    public decimal High { get; init; }
+
+    /// <summary>
+    /// Gets or sets the lowest price during the trading day.
+    /// </summary>
+    public decimal Low { get; init; }
+
+    /// <summary>
+    /// Gets or sets the closing price for the trading day.
+    /// </summary>
+    public decimal Close { get; init; }
+
+    /// <summary>
+    /// Gets or sets the trading volume for the day.
+    /// </summary>
+    public decimal Volume { get; init; }
+}

--- a/src/FinancialData/Entities/InvestmentAdviserInformation.cs
+++ b/src/FinancialData/Entities/InvestmentAdviserInformation.cs
@@ -7,87 +7,87 @@ namespace Tudormobile.FinancialData.Entities;
 public record InvestmentAdviserInformation
 {
     /// <summary>
-    /// Gets or sets the CRD (Central Registration Depository) number.
+    /// Gets the CRD (Central Registration Depository) number.
     /// </summary>
     public string? CrdNumber { get; init; }
 
     /// <summary>
-    /// Gets or sets the SEC file number.
+    /// Gets the SEC file number.
     /// </summary>
     public string? SecFileNumber { get; init; }
 
     /// <summary>
-    /// Gets or sets the firm name of the investment adviser.
+    /// Gets the firm name of the investment adviser.
     /// </summary>
     public string? FirmName { get; init; }
 
     /// <summary>
-    /// Gets or sets the filing date with the SEC.
+    /// Gets the filing date with the SEC.
     /// </summary>
     public DateOnly FilingDate { get; init; }
 
     /// <summary>
-    /// Gets or sets the street address.
+    /// Gets the street address.
     /// </summary>
     public string? AddressStreet { get; init; }
 
     /// <summary>
-    /// Gets or sets the city of the address.
+    /// Gets the city of the address.
     /// </summary>
     public string? AddressCity { get; init; }
 
     /// <summary>
-    /// Gets or sets the state of the address.
+    /// Gets the state of the address.
     /// </summary>
     public string? AddressState { get; init; }
 
     /// <summary>
-    /// Gets or sets the ZIP code of the address.
+    /// Gets the ZIP code of the address.
     /// </summary>
     public string? AddressZipCode { get; init; }
 
     /// <summary>
-    /// Gets or sets the country of the address.
+    /// Gets the country of the address.
     /// </summary>
     public string? AddressCountry { get; init; }
 
     /// <summary>
-    /// Gets or sets the phone number.
+    /// Gets the phone number.
     /// </summary>
     public string? PhoneNumber { get; init; }
 
     /// <summary>
-    /// Gets or sets the website URL.
+    /// Gets the website URL.
     /// </summary>
     public string? Website { get; init; }
 
     /// <summary>
-    /// Gets or sets the total assets under management.
+    /// Gets the total assets under management.
     /// </summary>
     public decimal AssetsUnderManagement { get; init; }
 
     /// <summary>
-    /// Gets or sets the number of employees.
+    /// Gets the number of employees.
     /// </summary>
     public int NumberOfEmployees { get; init; }
 
     /// <summary>
-    /// Gets or sets the number of clients.
+    /// Gets the number of clients.
     /// </summary>
     public int NumberOfClients { get; init; }
 
     /// <summary>
-    /// Gets or sets the number of high net worth individual clients.
+    /// Gets the number of high net worth individual clients.
     /// </summary>
     public int HighNetWorthClients { get; init; }
 
     /// <summary>
-    /// Gets or sets whether the adviser is a registered investment company.
+    /// Gets whether the adviser is a registered investment company.
     /// </summary>
     public bool IsRegisteredInvestmentCompany { get; init; }
 
     /// <summary>
-    /// Gets or sets whether the adviser is a private fund.
+    /// Gets whether the adviser is a private fund.
     /// </summary>
     public bool IsPrivateFund { get; init; }
 }

--- a/src/FinancialData/Entities/InvestmentAdviserInformation.cs
+++ b/src/FinancialData/Entities/InvestmentAdviserInformation.cs
@@ -1,0 +1,93 @@
+namespace Tudormobile.FinancialData.Entities;
+
+/// <summary>
+/// Represents detailed information about an investment adviser including assets under management, employees, and clients.
+/// <para>See: https://financialdata.net/documentation#investment_adviser_information</para>
+/// </summary>
+public record InvestmentAdviserInformation
+{
+    /// <summary>
+    /// Gets or sets the CRD (Central Registration Depository) number.
+    /// </summary>
+    public string? CrdNumber { get; init; }
+
+    /// <summary>
+    /// Gets or sets the SEC file number.
+    /// </summary>
+    public string? SecFileNumber { get; init; }
+
+    /// <summary>
+    /// Gets or sets the firm name of the investment adviser.
+    /// </summary>
+    public string? FirmName { get; init; }
+
+    /// <summary>
+    /// Gets or sets the filing date with the SEC.
+    /// </summary>
+    public DateOnly FilingDate { get; init; }
+
+    /// <summary>
+    /// Gets or sets the street address.
+    /// </summary>
+    public string? AddressStreet { get; init; }
+
+    /// <summary>
+    /// Gets or sets the city of the address.
+    /// </summary>
+    public string? AddressCity { get; init; }
+
+    /// <summary>
+    /// Gets or sets the state of the address.
+    /// </summary>
+    public string? AddressState { get; init; }
+
+    /// <summary>
+    /// Gets or sets the ZIP code of the address.
+    /// </summary>
+    public string? AddressZipCode { get; init; }
+
+    /// <summary>
+    /// Gets or sets the country of the address.
+    /// </summary>
+    public string? AddressCountry { get; init; }
+
+    /// <summary>
+    /// Gets or sets the phone number.
+    /// </summary>
+    public string? PhoneNumber { get; init; }
+
+    /// <summary>
+    /// Gets or sets the website URL.
+    /// </summary>
+    public string? Website { get; init; }
+
+    /// <summary>
+    /// Gets or sets the total assets under management.
+    /// </summary>
+    public decimal AssetsUnderManagement { get; init; }
+
+    /// <summary>
+    /// Gets or sets the number of employees.
+    /// </summary>
+    public int NumberOfEmployees { get; init; }
+
+    /// <summary>
+    /// Gets or sets the number of clients.
+    /// </summary>
+    public int NumberOfClients { get; init; }
+
+    /// <summary>
+    /// Gets or sets the number of high net worth individual clients.
+    /// </summary>
+    public int HighNetWorthClients { get; init; }
+
+    /// <summary>
+    /// Gets or sets whether the adviser is a registered investment company.
+    /// </summary>
+    public bool IsRegisteredInvestmentCompany { get; init; }
+
+    /// <summary>
+    /// Gets or sets whether the adviser is a private fund.
+    /// </summary>
+    public bool IsPrivateFund { get; init; }
+}

--- a/src/FinancialData/Entities/InvestmentAdviserName.cs
+++ b/src/FinancialData/Entities/InvestmentAdviserName.cs
@@ -1,0 +1,23 @@
+namespace Tudormobile.FinancialData.Entities;
+
+/// <summary>
+/// Represents an investment adviser with CRD number and firm name.
+/// <para>See: https://financialdata.net/documentation#investment_adviser_names</para>
+/// </summary>
+public record InvestmentAdviserName
+{
+    /// <summary>
+    /// Gets or sets the CRD (Central Registration Depository) number.
+    /// </summary>
+    public string? CrdNumber { get; init; }
+
+    /// <summary>
+    /// Gets or sets the SEC file number.
+    /// </summary>
+    public string? SecFileNumber { get; init; }
+
+    /// <summary>
+    /// Gets or sets the firm name of the investment adviser.
+    /// </summary>
+    public string? FirmName { get; init; }
+}

--- a/src/FinancialData/Entities/InvestmentAdviserName.cs
+++ b/src/FinancialData/Entities/InvestmentAdviserName.cs
@@ -7,17 +7,17 @@ namespace Tudormobile.FinancialData.Entities;
 public record InvestmentAdviserName
 {
     /// <summary>
-    /// Gets or sets the CRD (Central Registration Depository) number.
+    /// Gets the CRD (Central Registration Depository) number.
     /// </summary>
     public string? CrdNumber { get; init; }
 
     /// <summary>
-    /// Gets or sets the SEC file number.
+    /// Gets the SEC file number.
     /// </summary>
     public string? SecFileNumber { get; init; }
 
     /// <summary>
-    /// Gets or sets the firm name of the investment adviser.
+    /// Gets the firm name of the investment adviser.
     /// </summary>
     public string? FirmName { get; init; }
 }

--- a/src/FinancialData/Entities/IpoCalendar.cs
+++ b/src/FinancialData/Entities/IpoCalendar.cs
@@ -24,7 +24,7 @@ public record IpoCalendar
     /// <summary>
     /// Gets or sets the pricing date of the IPO.
     /// </summary>
-    public DateOnly PricingDate { get; init; }
+    public DateOnly IpoDate { get; init; }
 
     /// <summary>
     /// Gets or sets the share price.

--- a/src/FinancialData/Entities/IpoCalendar.cs
+++ b/src/FinancialData/Entities/IpoCalendar.cs
@@ -7,37 +7,37 @@ namespace Tudormobile.FinancialData.Entities;
 public record IpoCalendar
 {
     /// <summary>
-    /// Gets or sets the trading symbol of the company.
+    /// Gets the trading symbol of the company.
     /// </summary>
     public string? TradingSymbol { get; init; }
 
     /// <summary>
-    /// Gets or sets the registrant name of the company.
+    /// Gets the registrant name of the company.
     /// </summary>
     public string? RegistrantName { get; init; }
 
     /// <summary>
-    /// Gets or sets the stock exchange.
+    /// Gets the stock exchange.
     /// </summary>
     public string? Exchange { get; init; }
 
     /// <summary>
-    /// Gets or sets the pricing date of the IPO.
+    /// Gets the pricing date of the IPO.
     /// </summary>
     public DateOnly IpoDate { get; init; }
 
     /// <summary>
-    /// Gets or sets the share price.
+    /// Gets the share price.
     /// </summary>
     public decimal SharePrice { get; init; }
 
     /// <summary>
-    /// Gets or sets the number of shares offered.
+    /// Gets the number of shares offered.
     /// </summary>
     public decimal SharesOffered { get; init; }
 
     /// <summary>
-    /// Gets or sets the total offering value.
+    /// Gets the total offering value.
     /// </summary>
     public decimal OfferingValue { get; init; }
 }

--- a/src/FinancialData/Entities/IpoCalendar.cs
+++ b/src/FinancialData/Entities/IpoCalendar.cs
@@ -1,0 +1,43 @@
+namespace Tudormobile.FinancialData.Entities;
+
+/// <summary>
+/// Represents an upcoming initial public offering on the IPO calendar.
+/// <para>See: https://financialdata.net/documentation#ipo_calendar</para>
+/// </summary>
+public record IpoCalendar
+{
+    /// <summary>
+    /// Gets or sets the trading symbol of the company.
+    /// </summary>
+    public string? TradingSymbol { get; init; }
+
+    /// <summary>
+    /// Gets or sets the registrant name of the company.
+    /// </summary>
+    public string? RegistrantName { get; init; }
+
+    /// <summary>
+    /// Gets or sets the stock exchange.
+    /// </summary>
+    public string? Exchange { get; init; }
+
+    /// <summary>
+    /// Gets or sets the pricing date of the IPO.
+    /// </summary>
+    public DateOnly PricingDate { get; init; }
+
+    /// <summary>
+    /// Gets or sets the share price.
+    /// </summary>
+    public decimal SharePrice { get; init; }
+
+    /// <summary>
+    /// Gets or sets the number of shares offered.
+    /// </summary>
+    public decimal SharesOffered { get; init; }
+
+    /// <summary>
+    /// Gets or sets the total offering value.
+    /// </summary>
+    public decimal OfferingValue { get; init; }
+}

--- a/src/FinancialData/Entities/KeyMetrics.cs
+++ b/src/FinancialData/Entities/KeyMetrics.cs
@@ -7,122 +7,122 @@ namespace Tudormobile.FinancialData.Entities;
 public record KeyMetrics
 {
     /// <summary>
-    /// Gets or sets the trading symbol of the company.
+    /// Gets the trading symbol of the company.
     /// </summary>
     public string? TradingSymbol { get; init; }
 
     /// <summary>
-    /// Gets or sets the central index key (CIK) assigned by the SEC.
+    /// Gets the central index key (CIK) assigned by the SEC.
     /// </summary>
     public string? CentralIndexKey { get; init; }
 
     /// <summary>
-    /// Gets or sets the registrant name of the company.
+    /// Gets the registrant name of the company.
     /// </summary>
     public string? RegistrantName { get; init; }
 
     /// <summary>
-    /// Gets or sets the fiscal year.
+    /// Gets the fiscal year.
     /// </summary>
     public string? FiscalYear { get; init; }
 
     /// <summary>
-    /// Gets or sets the period end date.
+    /// Gets the period end date.
     /// </summary>
     public DateOnly PeriodEndDate { get; init; }
 
     /// <summary>
-    /// Gets or sets the earnings per share.
+    /// Gets the earnings per share.
     /// </summary>
     public decimal EarningsPerShare { get; init; }
 
     /// <summary>
-    /// Gets or sets the forecasted earnings per share.
+    /// Gets the forecasted earnings per share.
     /// </summary>
     public decimal EarningsPerShareForecast { get; init; }
 
     /// <summary>
-    /// Gets or sets the price-to-earnings ratio.
+    /// Gets the price-to-earnings ratio.
     /// </summary>
     public decimal PriceToEarningsRatio { get; init; }
 
     /// <summary>
-    /// Gets or sets the forward price-to-earnings ratio.
+    /// Gets the forward price-to-earnings ratio.
     /// </summary>
     public decimal ForwardPriceToEarningsRatio { get; init; }
 
     /// <summary>
-    /// Gets or sets the earnings growth rate.
+    /// Gets the earnings growth rate.
     /// </summary>
     public decimal EarningsGrowthRate { get; init; }
 
     /// <summary>
-    /// Gets or sets the price-earnings-to-growth (PEG) ratio.
+    /// Gets the price-earnings-to-growth (PEG) ratio.
     /// </summary>
     public decimal PriceEarningsToGrowthRatio { get; init; }
 
     /// <summary>
-    /// Gets or sets the book value per share.
+    /// Gets the book value per share.
     /// </summary>
     public decimal BookValuePerShare { get; init; }
 
     /// <summary>
-    /// Gets or sets the price-to-book ratio.
+    /// Gets the price-to-book ratio.
     /// </summary>
     public decimal PriceToBookRatio { get; init; }
 
     /// <summary>
-    /// Gets or sets the EBITDA.
+    /// Gets the EBITDA.
     /// </summary>
     public decimal Ebitda { get; init; }
 
     /// <summary>
-    /// Gets or sets the enterprise value.
+    /// Gets the enterprise value.
     /// </summary>
     public decimal EnterpriseValue { get; init; }
 
     /// <summary>
-    /// Gets or sets the dividend yield.
+    /// Gets the dividend yield.
     /// </summary>
     public decimal DividendYield { get; init; }
 
     /// <summary>
-    /// Gets or sets the dividend payout ratio.
+    /// Gets the dividend payout ratio.
     /// </summary>
     public decimal DividendPayoutRatio { get; init; }
 
     /// <summary>
-    /// Gets or sets the debt-to-equity ratio.
+    /// Gets the debt-to-equity ratio.
     /// </summary>
     public decimal DebtToEquityRatio { get; init; }
 
     /// <summary>
-    /// Gets or sets the capital expenditures.
+    /// Gets the capital expenditures.
     /// </summary>
     public decimal CapitalExpenditures { get; init; }
 
     /// <summary>
-    /// Gets or sets the free cash flow.
+    /// Gets the free cash flow.
     /// </summary>
     public decimal FreeCashFlow { get; init; }
 
     /// <summary>
-    /// Gets or sets the return on equity.
+    /// Gets the return on equity.
     /// </summary>
     public decimal ReturnOnEquity { get; init; }
 
     /// <summary>
-    /// Gets or sets the one-year beta.
+    /// Gets the one-year beta.
     /// </summary>
     public decimal OneYearBeta { get; init; }
 
     /// <summary>
-    /// Gets or sets the three-year beta.
+    /// Gets the three-year beta.
     /// </summary>
     public decimal ThreeYearBeta { get; init; }
 
     /// <summary>
-    /// Gets or sets the five-year beta.
+    /// Gets the five-year beta.
     /// </summary>
     public decimal FiveYearBeta { get; init; }
 }

--- a/src/FinancialData/Entities/KeyMetrics.cs
+++ b/src/FinancialData/Entities/KeyMetrics.cs
@@ -1,0 +1,128 @@
+namespace Tudormobile.FinancialData.Entities;
+
+/// <summary>
+/// Represents key financial metrics for a company such as P/E ratio, P/B ratio, free cash flow, etc.
+/// <para>See: https://financialdata.net/documentation#key_metrics</para>
+/// </summary>
+public record KeyMetrics
+{
+    /// <summary>
+    /// Gets or sets the trading symbol of the company.
+    /// </summary>
+    public string? TradingSymbol { get; init; }
+
+    /// <summary>
+    /// Gets or sets the central index key (CIK) assigned by the SEC.
+    /// </summary>
+    public string? CentralIndexKey { get; init; }
+
+    /// <summary>
+    /// Gets or sets the registrant name of the company.
+    /// </summary>
+    public string? RegistrantName { get; init; }
+
+    /// <summary>
+    /// Gets or sets the fiscal year.
+    /// </summary>
+    public string? FiscalYear { get; init; }
+
+    /// <summary>
+    /// Gets or sets the period end date.
+    /// </summary>
+    public DateOnly PeriodEndDate { get; init; }
+
+    /// <summary>
+    /// Gets or sets the earnings per share.
+    /// </summary>
+    public decimal EarningsPerShare { get; init; }
+
+    /// <summary>
+    /// Gets or sets the forecasted earnings per share.
+    /// </summary>
+    public decimal EarningsPerShareForecast { get; init; }
+
+    /// <summary>
+    /// Gets or sets the price-to-earnings ratio.
+    /// </summary>
+    public decimal PriceToEarningsRatio { get; init; }
+
+    /// <summary>
+    /// Gets or sets the forward price-to-earnings ratio.
+    /// </summary>
+    public decimal ForwardPriceToEarningsRatio { get; init; }
+
+    /// <summary>
+    /// Gets or sets the earnings growth rate.
+    /// </summary>
+    public decimal EarningsGrowthRate { get; init; }
+
+    /// <summary>
+    /// Gets or sets the price-earnings-to-growth (PEG) ratio.
+    /// </summary>
+    public decimal PriceEarningsToGrowthRatio { get; init; }
+
+    /// <summary>
+    /// Gets or sets the book value per share.
+    /// </summary>
+    public decimal BookValuePerShare { get; init; }
+
+    /// <summary>
+    /// Gets or sets the price-to-book ratio.
+    /// </summary>
+    public decimal PriceToBookRatio { get; init; }
+
+    /// <summary>
+    /// Gets or sets the EBITDA.
+    /// </summary>
+    public decimal Ebitda { get; init; }
+
+    /// <summary>
+    /// Gets or sets the enterprise value.
+    /// </summary>
+    public decimal EnterpriseValue { get; init; }
+
+    /// <summary>
+    /// Gets or sets the dividend yield.
+    /// </summary>
+    public decimal DividendYield { get; init; }
+
+    /// <summary>
+    /// Gets or sets the dividend payout ratio.
+    /// </summary>
+    public decimal DividendPayoutRatio { get; init; }
+
+    /// <summary>
+    /// Gets or sets the debt-to-equity ratio.
+    /// </summary>
+    public decimal DebtToEquityRatio { get; init; }
+
+    /// <summary>
+    /// Gets or sets the capital expenditures.
+    /// </summary>
+    public decimal CapitalExpenditures { get; init; }
+
+    /// <summary>
+    /// Gets or sets the free cash flow.
+    /// </summary>
+    public decimal FreeCashFlow { get; init; }
+
+    /// <summary>
+    /// Gets or sets the return on equity.
+    /// </summary>
+    public decimal ReturnOnEquity { get; init; }
+
+    /// <summary>
+    /// Gets or sets the one-year beta.
+    /// </summary>
+    public decimal OneYearBeta { get; init; }
+
+    /// <summary>
+    /// Gets or sets the three-year beta.
+    /// </summary>
+    public decimal ThreeYearBeta { get; init; }
+
+    /// <summary>
+    /// Gets or sets the five-year beta.
+    /// </summary>
+    public decimal FiveYearBeta { get; init; }
+}

--- a/src/FinancialData/Entities/LatestPrice.cs
+++ b/src/FinancialData/Entities/LatestPrice.cs
@@ -1,0 +1,43 @@
+namespace Tudormobile.FinancialData.Entities;
+
+/// <summary>
+/// Represents the latest one-minute price data for a security for the current week.
+/// <para>See: https://financialdata.net/documentation#latest_prices</para>
+/// </summary>
+public record LatestPrice
+{
+    /// <summary>
+    /// Gets or sets the trading symbol of the security.
+    /// </summary>
+    public string? TradingSymbol { get; init; }
+
+    /// <summary>
+    /// Gets or sets the timestamp of the price record (UTC).
+    /// </summary>
+    public DateTime Time { get; init; }
+
+    /// <summary>
+    /// Gets or sets the opening price for the one-minute period.
+    /// </summary>
+    public decimal Open { get; init; }
+
+    /// <summary>
+    /// Gets or sets the highest price during the one-minute period.
+    /// </summary>
+    public decimal High { get; init; }
+
+    /// <summary>
+    /// Gets or sets the lowest price during the one-minute period.
+    /// </summary>
+    public decimal Low { get; init; }
+
+    /// <summary>
+    /// Gets or sets the closing price for the one-minute period.
+    /// </summary>
+    public decimal Close { get; init; }
+
+    /// <summary>
+    /// Gets or sets the trading volume for the one-minute period.
+    /// </summary>
+    public decimal Volume { get; init; }
+}

--- a/src/FinancialData/Entities/LatestPrice.cs
+++ b/src/FinancialData/Entities/LatestPrice.cs
@@ -7,37 +7,37 @@ namespace Tudormobile.FinancialData.Entities;
 public record LatestPrice
 {
     /// <summary>
-    /// Gets or sets the trading symbol of the security.
+    /// Gets the trading symbol of the security.
     /// </summary>
     public string? TradingSymbol { get; init; }
 
     /// <summary>
-    /// Gets or sets the timestamp of the price record (UTC).
+    /// Gets the timestamp of the price record (UTC).
     /// </summary>
     public DateTime Time { get; init; }
 
     /// <summary>
-    /// Gets or sets the opening price for the one-minute period.
+    /// Gets the opening price for the one-minute period.
     /// </summary>
     public decimal Open { get; init; }
 
     /// <summary>
-    /// Gets or sets the highest price during the one-minute period.
+    /// Gets the highest price during the one-minute period.
     /// </summary>
     public decimal High { get; init; }
 
     /// <summary>
-    /// Gets or sets the lowest price during the one-minute period.
+    /// Gets the lowest price during the one-minute period.
     /// </summary>
     public decimal Low { get; init; }
 
     /// <summary>
-    /// Gets or sets the closing price for the one-minute period.
+    /// Gets the closing price for the one-minute period.
     /// </summary>
     public decimal Close { get; init; }
 
     /// <summary>
-    /// Gets or sets the trading volume for the one-minute period.
+    /// Gets the trading volume for the one-minute period.
     /// </summary>
     public decimal Volume { get; init; }
 }

--- a/src/FinancialData/Entities/MarketCap.cs
+++ b/src/FinancialData/Entities/MarketCap.cs
@@ -7,52 +7,52 @@ namespace Tudormobile.FinancialData.Entities;
 public record MarketCap
 {
     /// <summary>
-    /// Gets or sets the trading symbol of the company.
+    /// Gets the trading symbol of the company.
     /// </summary>
     public string? TradingSymbol { get; init; }
 
     /// <summary>
-    /// Gets or sets the central index key (CIK) assigned by the SEC.
+    /// Gets the central index key (CIK) assigned by the SEC.
     /// </summary>
     public string? CentralIndexKey { get; init; }
 
     /// <summary>
-    /// Gets or sets the registrant name of the company.
+    /// Gets the registrant name of the company.
     /// </summary>
     public string? RegistrantName { get; init; }
 
     /// <summary>
-    /// Gets or sets the fiscal year.
+    /// Gets the fiscal year.
     /// </summary>
     public string? FiscalYear { get; init; }
 
     /// <summary>
-    /// Gets or sets the market capitalization.
+    /// Gets the market capitalization.
     /// </summary>
     public decimal MarketCapValue { get; init; }
 
     /// <summary>
-    /// Gets or sets the change in market capitalization.
+    /// Gets the change in market capitalization.
     /// </summary>
     public decimal ChangeInMarketCap { get; init; }
 
     /// <summary>
-    /// Gets or sets the percentage change in market capitalization.
+    /// Gets the percentage change in market capitalization.
     /// </summary>
     public decimal PercentageChangeInMarketCap { get; init; }
 
     /// <summary>
-    /// Gets or sets the number of shares outstanding.
+    /// Gets the number of shares outstanding.
     /// </summary>
     public decimal SharesOutstanding { get; init; }
 
     /// <summary>
-    /// Gets or sets the change in shares outstanding.
+    /// Gets the change in shares outstanding.
     /// </summary>
     public decimal ChangeInSharesOutstanding { get; init; }
 
     /// <summary>
-    /// Gets or sets the percentage change in shares outstanding.
+    /// Gets the percentage change in shares outstanding.
     /// </summary>
     public decimal PercentageChangeInSharesOutstanding { get; init; }
 }

--- a/src/FinancialData/Entities/MarketCap.cs
+++ b/src/FinancialData/Entities/MarketCap.cs
@@ -1,0 +1,58 @@
+namespace Tudormobile.FinancialData.Entities;
+
+/// <summary>
+/// Represents historical market capitalization data for a company.
+/// <para>See: https://financialdata.net/documentation#market_cap</para>
+/// </summary>
+public record MarketCap
+{
+    /// <summary>
+    /// Gets or sets the trading symbol of the company.
+    /// </summary>
+    public string? TradingSymbol { get; init; }
+
+    /// <summary>
+    /// Gets or sets the central index key (CIK) assigned by the SEC.
+    /// </summary>
+    public string? CentralIndexKey { get; init; }
+
+    /// <summary>
+    /// Gets or sets the registrant name of the company.
+    /// </summary>
+    public string? RegistrantName { get; init; }
+
+    /// <summary>
+    /// Gets or sets the fiscal year.
+    /// </summary>
+    public string? FiscalYear { get; init; }
+
+    /// <summary>
+    /// Gets or sets the market capitalization.
+    /// </summary>
+    public decimal MarketCapValue { get; init; }
+
+    /// <summary>
+    /// Gets or sets the change in market capitalization.
+    /// </summary>
+    public decimal ChangeInMarketCap { get; init; }
+
+    /// <summary>
+    /// Gets or sets the percentage change in market capitalization.
+    /// </summary>
+    public decimal PercentageChangeInMarketCap { get; init; }
+
+    /// <summary>
+    /// Gets or sets the number of shares outstanding.
+    /// </summary>
+    public decimal SharesOutstanding { get; init; }
+
+    /// <summary>
+    /// Gets or sets the change in shares outstanding.
+    /// </summary>
+    public decimal ChangeInSharesOutstanding { get; init; }
+
+    /// <summary>
+    /// Gets or sets the percentage change in shares outstanding.
+    /// </summary>
+    public decimal PercentageChangeInSharesOutstanding { get; init; }
+}

--- a/src/FinancialData/Entities/MinutePrice.cs
+++ b/src/FinancialData/Entities/MinutePrice.cs
@@ -1,0 +1,43 @@
+namespace Tudormobile.FinancialData.Entities;
+
+/// <summary>
+/// Represents one-minute historical price data for a security, including open, high, low, close, and volume.
+/// <para>See: https://financialdata.net/documentation#minute_prices</para>
+/// </summary>
+public record MinutePrice
+{
+    /// <summary>
+    /// Gets or sets the trading symbol of the security.
+    /// </summary>
+    public string? TradingSymbol { get; init; }
+
+    /// <summary>
+    /// Gets or sets the timestamp of the minute price record (UTC).
+    /// </summary>
+    public DateTime Time { get; init; }
+
+    /// <summary>
+    /// Gets or sets the opening price for the one-minute period.
+    /// </summary>
+    public decimal Open { get; init; }
+
+    /// <summary>
+    /// Gets or sets the highest price during the one-minute period.
+    /// </summary>
+    public decimal High { get; init; }
+
+    /// <summary>
+    /// Gets or sets the lowest price during the one-minute period.
+    /// </summary>
+    public decimal Low { get; init; }
+
+    /// <summary>
+    /// Gets or sets the closing price for the one-minute period.
+    /// </summary>
+    public decimal Close { get; init; }
+
+    /// <summary>
+    /// Gets or sets the trading volume for the one-minute period.
+    /// </summary>
+    public decimal Volume { get; init; }
+}

--- a/src/FinancialData/Entities/MinutePrice.cs
+++ b/src/FinancialData/Entities/MinutePrice.cs
@@ -7,37 +7,37 @@ namespace Tudormobile.FinancialData.Entities;
 public record MinutePrice
 {
     /// <summary>
-    /// Gets or sets the trading symbol of the security.
+    /// Gets the trading symbol of the security.
     /// </summary>
     public string? TradingSymbol { get; init; }
 
     /// <summary>
-    /// Gets or sets the timestamp of the minute price record (UTC).
+    /// Gets the timestamp of the minute price record (UTC).
     /// </summary>
     public DateTime Time { get; init; }
 
     /// <summary>
-    /// Gets or sets the opening price for the one-minute period.
+    /// Gets the opening price for the one-minute period.
     /// </summary>
     public decimal Open { get; init; }
 
     /// <summary>
-    /// Gets or sets the highest price during the one-minute period.
+    /// Gets the highest price during the one-minute period.
     /// </summary>
     public decimal High { get; init; }
 
     /// <summary>
-    /// Gets or sets the lowest price during the one-minute period.
+    /// Gets the lowest price during the one-minute period.
     /// </summary>
     public decimal Low { get; init; }
 
     /// <summary>
-    /// Gets or sets the closing price for the one-minute period.
+    /// Gets the closing price for the one-minute period.
     /// </summary>
     public decimal Close { get; init; }
 
     /// <summary>
-    /// Gets or sets the trading volume for the one-minute period.
+    /// Gets the trading volume for the one-minute period.
     /// </summary>
     public decimal Volume { get; init; }
 }

--- a/src/FinancialData/Entities/MutualFundHoldings.cs
+++ b/src/FinancialData/Entities/MutualFundHoldings.cs
@@ -1,0 +1,174 @@
+﻿namespace Tudormobile.FinancialData.Entities;
+
+/// <summary>
+/// Represents the holdings of a mutual fund, including details such as fund identifiers, issuer information, 
+/// and asset characteristics.
+/// </summary>
+public record MutualFundHoldings
+{
+    /// <summary>
+    /// Gets or sets the unique central index key for the mutual fund.
+    /// </summary>
+    public string? CentralIndexKey { get; init; }
+
+    /// <summary>
+    /// Gets or sets the name of the registrant (fund family or provider).
+    /// </summary>
+    public string? RegistrantName { get; init; }
+
+    /// <summary>
+    /// Gets or sets the period of report (end date of the reporting period).
+    /// </summary>
+    public DateOnly? PeriodOfReport { get; init; }
+
+    /// <summary>
+    /// Gets or sets the name of the mutual fund.
+    /// </summary>
+    public string? FundName { get; init; }
+
+    /// <summary>
+    /// Gets or sets the symbol of the mutual fund.
+    /// </summary>
+    public string? FundSymbol { get; init; }
+
+    /// <summary>
+    /// Gets or sets the series ID of the mutual fund.
+    /// </summary>
+    public string? SeriesId { get; init; }
+
+    /// <summary>
+    /// Gets or sets the class ID of the mutual fund.
+    /// </summary>
+    public string? ClassId { get; init; }
+
+    /// <summary>
+    /// Gets or sets the issuer name of the holding.
+    /// </summary>
+    public string? IssuerName { get; init; }
+
+    /// <summary>
+    /// Gets or sets the Legal Entity Identifier (LEI) number of the issuer.
+    /// </summary>
+    public string? LeiNumber { get; init; }
+
+    /// <summary>
+    /// Gets or sets the title of the security.
+    /// </summary>
+    public string? TitleOfSecurity { get; init; }
+
+    /// <summary>
+    /// Gets or sets the trading symbol of the security.
+    /// </summary>
+    public string? TradingSymbol { get; init; }
+
+    /// <summary>
+    /// Gets or sets the CUSIP number of the security.
+    /// </summary>
+    public string? CusipNumber { get; init; }
+
+    /// <summary>
+    /// Gets or sets the ISIN number of the security.
+    /// </summary>
+    public string? IsinNumber { get; init; }
+
+    /// <summary>
+    /// Gets or sets the amount of units held.
+    /// </summary>
+    public decimal? AmountOfUnits { get; init; }
+
+    /// <summary>
+    /// Gets or sets the description of units.
+    /// </summary>
+    public string? DescriptionOfUnits { get; init; }
+
+    /// <summary>
+    /// Gets or sets the denomination currency.
+    /// </summary>
+    public string? DenominationCurrency { get; init; }
+
+    /// <summary>
+    /// Gets or sets the value in USD.
+    /// </summary>
+    public decimal? ValueInUsd { get; init; }
+
+    /// <summary>
+    /// Gets or sets the percentage value compared to assets.
+    /// </summary>
+    public decimal? PercentageValueComparedToAssets { get; init; }
+
+    /// <summary>
+    /// Gets or sets the payoff profile (e.g., Long/Short).
+    /// </summary>
+    public string? PayoffProfile { get; init; }
+
+    /// <summary>
+    /// Gets or sets the asset type.
+    /// </summary>
+    public string? AssetType { get; init; }
+
+    /// <summary>
+    /// Gets or sets the issuer type.
+    /// </summary>
+    public string? IssuerType { get; init; }
+
+    /// <summary>
+    /// Gets or sets the country of issuer or investment.
+    /// </summary>
+    public string? CountryOfIssuerOrInvestment { get; init; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the security is restricted.
+    /// </summary>
+    public bool? IsRestrictedSecurity { get; init; }
+
+    /// <summary>
+    /// Gets or sets the fair value level.
+    /// </summary>
+    public int? FairValueLevel { get; init; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether this is cash collateral.
+    /// </summary>
+    public bool? IsCashCollateral { get; init; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether this is non-cash collateral.
+    /// </summary>
+    public bool? IsNonCashCollateral { get; init; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether this is a loan by the fund.
+    /// </summary>
+    public bool? IsLoanByFund { get; init; }
+}
+/* ref: https://financialdata.net/documentation#mutual_fund_holdings
+{
+    "central_index_key": "0000036405",
+    "registrant_name": "VANGUARD INDEX FUNDS",
+    "period_of_report": "2025-06-30",
+    "fund_name": "Admiral Shares",
+    "fund_symbol": "VTSAX",
+    "series_id": "S000002848",
+    "class_id": "C000007806",
+    "issuer_name": "Frequency Electronics Inc",
+    "lei_number": "549300S56SO2JB5JBE31",
+    "title_of_security": "FREQUENCY ELECT",
+    "trading_symbol": "FEIM",
+    "cusip_number": "358010106",
+    "isin_number": "US3580101067",
+    "amount_of_units": 228179,
+    "description_of_units": "NS",
+    "denomination_currency": "USD",
+    "value_in_usd": 5181945.09,
+    "percentage_value_compared_to_assets": 0.000271384232,
+    "payoff_profile": "Long",
+    "asset_type": "EC",
+    "issuer_type": "CORP",
+    "country_of_issuer_or_investment": "US",
+    "is_restricted_security": false,
+    "fair_value_level": 1,
+    "is_cash_collateral": false,
+    "is_non_cash_collateral": false,
+    "is_loan_by_fund": true
+  }
+*/

--- a/src/FinancialData/Entities/MutualFundHoldings.cs
+++ b/src/FinancialData/Entities/MutualFundHoldings.cs
@@ -1,4 +1,4 @@
-﻿namespace Tudormobile.FinancialData.Entities;
+namespace Tudormobile.FinancialData.Entities;
 
 /// <summary>
 /// Represents the holdings of a mutual fund, including details such as fund identifiers, issuer information, 
@@ -7,137 +7,137 @@
 public record MutualFundHoldings
 {
     /// <summary>
-    /// Gets or sets the unique central index key for the mutual fund.
+    /// Gets the unique central index key for the mutual fund.
     /// </summary>
     public string? CentralIndexKey { get; init; }
 
     /// <summary>
-    /// Gets or sets the name of the registrant (fund family or provider).
+    /// Gets the name of the registrant (fund family or provider).
     /// </summary>
     public string? RegistrantName { get; init; }
 
     /// <summary>
-    /// Gets or sets the period of report (end date of the reporting period).
+    /// Gets the period of report (end date of the reporting period).
     /// </summary>
     public DateOnly? PeriodOfReport { get; init; }
 
     /// <summary>
-    /// Gets or sets the name of the mutual fund.
+    /// Gets the name of the mutual fund.
     /// </summary>
     public string? FundName { get; init; }
 
     /// <summary>
-    /// Gets or sets the symbol of the mutual fund.
+    /// Gets the symbol of the mutual fund.
     /// </summary>
     public string? FundSymbol { get; init; }
 
     /// <summary>
-    /// Gets or sets the series ID of the mutual fund.
+    /// Gets the series ID of the mutual fund.
     /// </summary>
     public string? SeriesId { get; init; }
 
     /// <summary>
-    /// Gets or sets the class ID of the mutual fund.
+    /// Gets the class ID of the mutual fund.
     /// </summary>
     public string? ClassId { get; init; }
 
     /// <summary>
-    /// Gets or sets the issuer name of the holding.
+    /// Gets the issuer name of the holding.
     /// </summary>
     public string? IssuerName { get; init; }
 
     /// <summary>
-    /// Gets or sets the Legal Entity Identifier (LEI) number of the issuer.
+    /// Gets the Legal Entity Identifier (LEI) number of the issuer.
     /// </summary>
     public string? LeiNumber { get; init; }
 
     /// <summary>
-    /// Gets or sets the title of the security.
+    /// Gets the title of the security.
     /// </summary>
     public string? TitleOfSecurity { get; init; }
 
     /// <summary>
-    /// Gets or sets the trading symbol of the security.
+    /// Gets the trading symbol of the security.
     /// </summary>
     public string? TradingSymbol { get; init; }
 
     /// <summary>
-    /// Gets or sets the CUSIP number of the security.
+    /// Gets the CUSIP number of the security.
     /// </summary>
     public string? CusipNumber { get; init; }
 
     /// <summary>
-    /// Gets or sets the ISIN number of the security.
+    /// Gets the ISIN number of the security.
     /// </summary>
     public string? IsinNumber { get; init; }
 
     /// <summary>
-    /// Gets or sets the amount of units held.
+    /// Gets the amount of units held.
     /// </summary>
-    public decimal? AmountOfUnits { get; init; }
+    public decimal AmountOfUnits { get; init; }
 
     /// <summary>
-    /// Gets or sets the description of units.
+    /// Gets the description of units.
     /// </summary>
     public string? DescriptionOfUnits { get; init; }
 
     /// <summary>
-    /// Gets or sets the denomination currency.
+    /// Gets the denomination currency.
     /// </summary>
     public string? DenominationCurrency { get; init; }
 
     /// <summary>
-    /// Gets or sets the value in USD.
+    /// Gets the value in USD.
     /// </summary>
-    public decimal? ValueInUsd { get; init; }
+    public decimal ValueInUsd { get; init; }
 
     /// <summary>
-    /// Gets or sets the percentage value compared to assets.
+    /// Gets the percentage value compared to assets.
     /// </summary>
-    public decimal? PercentageValueComparedToAssets { get; init; }
+    public decimal PercentageValueComparedToAssets { get; init; }
 
     /// <summary>
-    /// Gets or sets the payoff profile (e.g., Long/Short).
+    /// Gets the payoff profile (e.g., Long/Short).
     /// </summary>
     public string? PayoffProfile { get; init; }
 
     /// <summary>
-    /// Gets or sets the asset type.
+    /// Gets the asset type.
     /// </summary>
     public string? AssetType { get; init; }
 
     /// <summary>
-    /// Gets or sets the issuer type.
+    /// Gets the issuer type.
     /// </summary>
     public string? IssuerType { get; init; }
 
     /// <summary>
-    /// Gets or sets the country of issuer or investment.
+    /// Gets the country of issuer or investment.
     /// </summary>
     public string? CountryOfIssuerOrInvestment { get; init; }
 
     /// <summary>
-    /// Gets or sets a value indicating whether the security is restricted.
+    /// Gets a value indicating whether the security is restricted.
     /// </summary>
     public bool? IsRestrictedSecurity { get; init; }
 
     /// <summary>
-    /// Gets or sets the fair value level.
+    /// Gets the fair value level.
     /// </summary>
     public int? FairValueLevel { get; init; }
 
     /// <summary>
-    /// Gets or sets a value indicating whether this is cash collateral.
+    /// Gets a value indicating whether this is cash collateral.
     /// </summary>
     public bool? IsCashCollateral { get; init; }
 
     /// <summary>
-    /// Gets or sets a value indicating whether this is non-cash collateral.
+    /// Gets a value indicating whether this is non-cash collateral.
     /// </summary>
     public bool? IsNonCashCollateral { get; init; }
 
     /// <summary>
-    /// Gets or sets a value indicating whether this is a loan by the fund.
+    /// Gets a value indicating whether this is a loan by the fund.
     /// </summary>
     public bool? IsLoanByFund { get; init; }
 }

--- a/src/FinancialData/Entities/MutualFundStatistics.cs
+++ b/src/FinancialData/Entities/MutualFundStatistics.cs
@@ -1,0 +1,163 @@
+﻿namespace Tudormobile.FinancialData.Entities;
+
+/// <summary>
+/// Represents a collection of key financial and performance statistics for a mutual fund over a specified reporting
+/// period.
+/// </summary>
+public record MutualFundStatistics
+{
+    /// <summary>
+    /// Gets or sets the unique central index key for the mutual fund.
+    /// </summary>
+    public string? CentralIndexKey { get; init; }
+
+    /// <summary>
+    /// Gets or sets the name of the registrant (fund family or provider).
+    /// </summary>
+    public string? RegistrantName { get; init; }
+
+    /// <summary>
+    /// Gets or sets the period of report (end date of the reporting period).
+    /// </summary>
+    public DateOnly? PeriodOfReport { get; init; }
+
+    /// <summary>
+    /// Gets or sets the name of the mutual fund.
+    /// </summary>
+    public string? FundName { get; init; }
+
+    /// <summary>
+    /// Gets or sets the symbol of the mutual fund.
+    /// </summary>
+    public string? FundSymbol { get; init; }
+
+    /// <summary>
+    /// Gets or sets the series ID of the mutual fund.
+    /// </summary>
+    public string? SeriesId { get; init; }
+
+    /// <summary>
+    /// Gets or sets the class ID of the mutual fund.
+    /// </summary>
+    public string? ClassId { get; init; }
+
+    /// <summary>
+    /// Gets or sets the total assets of the mutual fund.
+    /// </summary>
+    public decimal? TotalAssets { get; init; }
+
+    /// <summary>
+    /// Gets or sets the total liabilities of the mutual fund.
+    /// </summary>
+    public decimal? TotalLiabilities { get; init; }
+
+    /// <summary>
+    /// Gets or sets the net assets of the mutual fund.
+    /// </summary>
+    public decimal? NetAssets { get; init; }
+
+    /// <summary>
+    /// Gets or sets the return for the preceding month 1 (as a percentage).
+    /// </summary>
+    public decimal? ReturnPrecedingMonth1 { get; init; }
+
+    /// <summary>
+    /// Gets or sets the return for the preceding month 2 (as a percentage).
+    /// </summary>
+    public decimal? ReturnPrecedingMonth2 { get; init; }
+
+    /// <summary>
+    /// Gets or sets the return for the preceding month 3 (as a percentage).
+    /// </summary>
+    public decimal? ReturnPrecedingMonth3 { get; init; }
+
+    /// <summary>
+    /// Gets or sets the realized gain for the preceding month 1.
+    /// </summary>
+    public decimal? RealizedGainPrecedingMonth1 { get; init; }
+
+    /// <summary>
+    /// Gets or sets the change in unrealized appreciation for the preceding month 1.
+    /// </summary>
+    public decimal? ChangeInUnrealizedAppreciationPrecedingMonth1 { get; init; }
+
+    /// <summary>
+    /// Gets or sets the realized gain for the preceding month 2.
+    /// </summary>
+    public decimal? RealizedGainPrecedingMonth2 { get; init; }
+
+    /// <summary>
+    /// Gets or sets the change in unrealized appreciation for the preceding month 2.
+    /// </summary>
+    public decimal? ChangeInUnrealizedAppreciationPrecedingMonth2 { get; init; }
+
+    /// <summary>
+    /// Gets or sets the realized gain for the preceding month 3.
+    /// </summary>
+    public decimal? RealizedGainPrecedingMonth3 { get; init; }
+
+    /// <summary>
+    /// Gets or sets the change in unrealized appreciation for the preceding month 3.
+    /// </summary>
+    public decimal? ChangeInUnrealizedAppreciationPrecedingMonth3 { get; init; }
+
+    /// <summary>
+    /// Gets or sets the share sale amount for the preceding month 1.
+    /// </summary>
+    public decimal? ShareSalePrecedingMonth1 { get; init; }
+
+    /// <summary>
+    /// Gets or sets the share redemption amount for the preceding month 1.
+    /// </summary>
+    public decimal? ShareRedemptionPrecedingMonth1 { get; init; }
+
+    /// <summary>
+    /// Gets or sets the share sale amount for the preceding month 2.
+    /// </summary>
+    public decimal? ShareSalePrecedingMonth2 { get; init; }
+
+    /// <summary>
+    /// Gets or sets the share redemption amount for the preceding month 2.
+    /// </summary>
+    public decimal? ShareRedemptionPrecedingMonth2 { get; init; }
+
+    /// <summary>
+    /// Gets or sets the share sale amount for the preceding month 3.
+    /// </summary>
+    public decimal? ShareSalePrecedingMonth3 { get; init; }
+
+    /// <summary>
+    /// Gets or sets the share redemption amount for the preceding month 3.
+    /// </summary>
+    public decimal? ShareRedemptionPrecedingMonth3 { get; init; }
+}
+
+/* ref: https://financialdata.net/documentation#mutual_fund_statistics
+{
+    "central_index_key": "0000036405",
+    "registrant_name": "VANGUARD INDEX FUNDS",
+    "period_of_report": "2025-06-30",
+    "fund_name": "Admiral Shares",
+    "fund_symbol": "VTSAX",
+    "series_id": "S000002848",
+    "class_id": "C000007806",
+    "total_assets": 1915212703487.01,
+    "total_liabilities": 5763123365.99,
+    "net_assets": 1909449580121.02,
+    "return_preceding_month1": -0.6729,
+    "return_preceding_month2": 6.3455,
+    "return_preceding_month3": 5.07574,
+    "realized_gain_preceding_month1": 983065935.64,
+    "change_in_unrealized_appreciation_preceding_month1": -11394591977.19,
+    "realized_gain_preceding_month2": 287029511.93,
+    "change_in_unrealized_appreciation_preceding_month2": 105734824564.66,
+    "realized_gain_preceding_month3": 2243886605.76,
+    "change_in_unrealized_appreciation_preceding_month3": 87596494350.2,
+    "share_sale_preceding_month1": 30533447572.6504,
+    "share_redemption_preceding_month1": 9354960674.63,
+    "share_sale_preceding_month2": 9024030148.45996,
+    "share_redemption_preceding_month2": 9833704993.95,
+    "share_sale_preceding_month3": 12681244786.0796,
+    "share_redemption_preceding_month3": 12999259996.1
+}
+*/

--- a/src/FinancialData/Entities/MutualFundStatistics.cs
+++ b/src/FinancialData/Entities/MutualFundStatistics.cs
@@ -1,4 +1,4 @@
-﻿namespace Tudormobile.FinancialData.Entities;
+namespace Tudormobile.FinancialData.Entities;
 
 /// <summary>
 /// Represents a collection of key financial and performance statistics for a mutual fund over a specified reporting
@@ -7,129 +7,129 @@
 public record MutualFundStatistics
 {
     /// <summary>
-    /// Gets or sets the unique central index key for the mutual fund.
+    /// Gets the unique central index key for the mutual fund.
     /// </summary>
     public string? CentralIndexKey { get; init; }
 
     /// <summary>
-    /// Gets or sets the name of the registrant (fund family or provider).
+    /// Gets the name of the registrant (fund family or provider).
     /// </summary>
     public string? RegistrantName { get; init; }
 
     /// <summary>
-    /// Gets or sets the period of report (end date of the reporting period).
+    /// Gets the period of report (end date of the reporting period).
     /// </summary>
     public DateOnly? PeriodOfReport { get; init; }
 
     /// <summary>
-    /// Gets or sets the name of the mutual fund.
+    /// Gets the name of the mutual fund.
     /// </summary>
     public string? FundName { get; init; }
 
     /// <summary>
-    /// Gets or sets the symbol of the mutual fund.
+    /// Gets the symbol of the mutual fund.
     /// </summary>
     public string? FundSymbol { get; init; }
 
     /// <summary>
-    /// Gets or sets the series ID of the mutual fund.
+    /// Gets the series ID of the mutual fund.
     /// </summary>
     public string? SeriesId { get; init; }
 
     /// <summary>
-    /// Gets or sets the class ID of the mutual fund.
+    /// Gets the class ID of the mutual fund.
     /// </summary>
     public string? ClassId { get; init; }
 
     /// <summary>
-    /// Gets or sets the total assets of the mutual fund.
+    /// Gets the total assets of the mutual fund.
     /// </summary>
-    public decimal? TotalAssets { get; init; }
+    public decimal TotalAssets { get; init; }
 
     /// <summary>
-    /// Gets or sets the total liabilities of the mutual fund.
+    /// Gets the total liabilities of the mutual fund.
     /// </summary>
-    public decimal? TotalLiabilities { get; init; }
+    public decimal TotalLiabilities { get; init; }
 
     /// <summary>
-    /// Gets or sets the net assets of the mutual fund.
+    /// Gets the net assets of the mutual fund.
     /// </summary>
-    public decimal? NetAssets { get; init; }
+    public decimal NetAssets { get; init; }
 
     /// <summary>
-    /// Gets or sets the return for the preceding month 1 (as a percentage).
+    /// Gets the return for the preceding month 1 (as a percentage).
     /// </summary>
-    public decimal? ReturnPrecedingMonth1 { get; init; }
+    public decimal ReturnPrecedingMonth1 { get; init; }
 
     /// <summary>
-    /// Gets or sets the return for the preceding month 2 (as a percentage).
+    /// Gets the return for the preceding month 2 (as a percentage).
     /// </summary>
-    public decimal? ReturnPrecedingMonth2 { get; init; }
+    public decimal ReturnPrecedingMonth2 { get; init; }
 
     /// <summary>
-    /// Gets or sets the return for the preceding month 3 (as a percentage).
+    /// Gets the return for the preceding month 3 (as a percentage).
     /// </summary>
-    public decimal? ReturnPrecedingMonth3 { get; init; }
+    public decimal ReturnPrecedingMonth3 { get; init; }
 
     /// <summary>
-    /// Gets or sets the realized gain for the preceding month 1.
+    /// Gets the realized gain for the preceding month 1.
     /// </summary>
-    public decimal? RealizedGainPrecedingMonth1 { get; init; }
+    public decimal RealizedGainPrecedingMonth1 { get; init; }
 
     /// <summary>
-    /// Gets or sets the change in unrealized appreciation for the preceding month 1.
+    /// Gets the change in unrealized appreciation for the preceding month 1.
     /// </summary>
-    public decimal? ChangeInUnrealizedAppreciationPrecedingMonth1 { get; init; }
+    public decimal ChangeInUnrealizedAppreciationPrecedingMonth1 { get; init; }
 
     /// <summary>
-    /// Gets or sets the realized gain for the preceding month 2.
+    /// Gets the realized gain for the preceding month 2.
     /// </summary>
-    public decimal? RealizedGainPrecedingMonth2 { get; init; }
+    public decimal RealizedGainPrecedingMonth2 { get; init; }
 
     /// <summary>
-    /// Gets or sets the change in unrealized appreciation for the preceding month 2.
+    /// Gets the change in unrealized appreciation for the preceding month 2.
     /// </summary>
-    public decimal? ChangeInUnrealizedAppreciationPrecedingMonth2 { get; init; }
+    public decimal ChangeInUnrealizedAppreciationPrecedingMonth2 { get; init; }
 
     /// <summary>
-    /// Gets or sets the realized gain for the preceding month 3.
+    /// Gets the realized gain for the preceding month 3.
     /// </summary>
-    public decimal? RealizedGainPrecedingMonth3 { get; init; }
+    public decimal RealizedGainPrecedingMonth3 { get; init; }
 
     /// <summary>
-    /// Gets or sets the change in unrealized appreciation for the preceding month 3.
+    /// Gets the change in unrealized appreciation for the preceding month 3.
     /// </summary>
-    public decimal? ChangeInUnrealizedAppreciationPrecedingMonth3 { get; init; }
+    public decimal ChangeInUnrealizedAppreciationPrecedingMonth3 { get; init; }
 
     /// <summary>
-    /// Gets or sets the share sale amount for the preceding month 1.
+    /// Gets the share sale amount for the preceding month 1.
     /// </summary>
-    public decimal? ShareSalePrecedingMonth1 { get; init; }
+    public decimal ShareSalePrecedingMonth1 { get; init; }
 
     /// <summary>
-    /// Gets or sets the share redemption amount for the preceding month 1.
+    /// Gets the share redemption amount for the preceding month 1.
     /// </summary>
-    public decimal? ShareRedemptionPrecedingMonth1 { get; init; }
+    public decimal ShareRedemptionPrecedingMonth1 { get; init; }
 
     /// <summary>
-    /// Gets or sets the share sale amount for the preceding month 2.
+    /// Gets the share sale amount for the preceding month 2.
     /// </summary>
-    public decimal? ShareSalePrecedingMonth2 { get; init; }
+    public decimal ShareSalePrecedingMonth2 { get; init; }
 
     /// <summary>
-    /// Gets or sets the share redemption amount for the preceding month 2.
+    /// Gets the share redemption amount for the preceding month 2.
     /// </summary>
-    public decimal? ShareRedemptionPrecedingMonth2 { get; init; }
+    public decimal ShareRedemptionPrecedingMonth2 { get; init; }
 
     /// <summary>
-    /// Gets or sets the share sale amount for the preceding month 3.
+    /// Gets the share sale amount for the preceding month 3.
     /// </summary>
-    public decimal? ShareSalePrecedingMonth3 { get; init; }
+    public decimal ShareSalePrecedingMonth3 { get; init; }
 
     /// <summary>
-    /// Gets or sets the share redemption amount for the preceding month 3.
+    /// Gets the share redemption amount for the preceding month 3.
     /// </summary>
-    public decimal? ShareRedemptionPrecedingMonth3 { get; init; }
+    public decimal ShareRedemptionPrecedingMonth3 { get; init; }
 }
 
 /* ref: https://financialdata.net/documentation#mutual_fund_statistics

--- a/src/FinancialData/Entities/MutualFundSymbol.cs
+++ b/src/FinancialData/Entities/MutualFundSymbol.cs
@@ -1,0 +1,23 @@
+﻿namespace Tudormobile.FinancialData.Entities;
+
+/// <summary>
+/// Represents a mutual fund symbol, including its trading symbol and name.
+/// </summary>
+public record MutualFundSymbol
+{
+    /// <summary>
+    /// Gets or sets the trading symbol of the mutual fund.
+    /// </summary>
+    public string? TradingSymbol { get; init; }
+
+    /// <summary>
+    /// Gets or sets the name of the mutual fund.
+    /// </summary>
+    public string? FundName { get; init; }
+}
+/* ref: https://financialdata.net/documentation#mutual_fund_symbols
+{
+    "trading_symbol": "AAAAX",
+    "fund_name": "DWS RREEF Real Assets Fund, Class A"
+}
+*/

--- a/src/FinancialData/Entities/MutualFundSymbol.cs
+++ b/src/FinancialData/Entities/MutualFundSymbol.cs
@@ -1,4 +1,4 @@
-﻿namespace Tudormobile.FinancialData.Entities;
+namespace Tudormobile.FinancialData.Entities;
 
 /// <summary>
 /// Represents a mutual fund symbol, including its trading symbol and name.
@@ -6,12 +6,12 @@
 public record MutualFundSymbol
 {
     /// <summary>
-    /// Gets or sets the trading symbol of the mutual fund.
+    /// Gets the trading symbol of the mutual fund.
     /// </summary>
     public string? TradingSymbol { get; init; }
 
     /// <summary>
-    /// Gets or sets the name of the mutual fund.
+    /// Gets the name of the mutual fund.
     /// </summary>
     public string? FundName { get; init; }
 }

--- a/src/FinancialData/Entities/OptionChain.cs
+++ b/src/FinancialData/Entities/OptionChain.cs
@@ -1,0 +1,43 @@
+namespace Tudormobile.FinancialData.Entities;
+
+/// <summary>
+/// Represents an option contract in an option chain, including expiration date, strike price, and contract type.
+/// <para>See: https://financialdata.net/documentation#option_chain</para>
+/// </summary>
+public record OptionChain
+{
+    /// <summary>
+    /// Gets or sets the trading symbol of the underlying security.
+    /// </summary>
+    public string? TradingSymbol { get; init; }
+
+    /// <summary>
+    /// Gets or sets the central index key (CIK) assigned by the SEC.
+    /// </summary>
+    public string? CentralIndexKey { get; init; }
+
+    /// <summary>
+    /// Gets or sets the registrant name of the company.
+    /// </summary>
+    public string? RegistrantName { get; init; }
+
+    /// <summary>
+    /// Gets or sets the option contract name.
+    /// </summary>
+    public string? ContractName { get; init; }
+
+    /// <summary>
+    /// Gets or sets the expiration date of the option.
+    /// </summary>
+    public DateOnly ExpirationDate { get; init; }
+
+    /// <summary>
+    /// Gets or sets whether the option is a Put or Call.
+    /// </summary>
+    public string? PutOrCall { get; init; }
+
+    /// <summary>
+    /// Gets or sets the strike price.
+    /// </summary>
+    public decimal StrikePrice { get; init; }
+}

--- a/src/FinancialData/Entities/OptionChain.cs
+++ b/src/FinancialData/Entities/OptionChain.cs
@@ -7,37 +7,37 @@ namespace Tudormobile.FinancialData.Entities;
 public record OptionChain
 {
     /// <summary>
-    /// Gets or sets the trading symbol of the underlying security.
+    /// Gets the trading symbol of the underlying security.
     /// </summary>
     public string? TradingSymbol { get; init; }
 
     /// <summary>
-    /// Gets or sets the central index key (CIK) assigned by the SEC.
+    /// Gets the central index key (CIK) assigned by the SEC.
     /// </summary>
     public string? CentralIndexKey { get; init; }
 
     /// <summary>
-    /// Gets or sets the registrant name of the company.
+    /// Gets the registrant name of the company.
     /// </summary>
     public string? RegistrantName { get; init; }
 
     /// <summary>
-    /// Gets or sets the option contract name.
+    /// Gets the option contract name.
     /// </summary>
     public string? ContractName { get; init; }
 
     /// <summary>
-    /// Gets or sets the expiration date of the option.
+    /// Gets the expiration date of the option.
     /// </summary>
     public DateOnly ExpirationDate { get; init; }
 
     /// <summary>
-    /// Gets or sets whether the option is a Put or Call.
+    /// Gets whether the option is a Put or Call.
     /// </summary>
     public string? PutOrCall { get; init; }
 
     /// <summary>
-    /// Gets or sets the strike price.
+    /// Gets the strike price.
     /// </summary>
     public decimal StrikePrice { get; init; }
 }

--- a/src/FinancialData/Entities/OptionGreeks.cs
+++ b/src/FinancialData/Entities/OptionGreeks.cs
@@ -1,0 +1,43 @@
+namespace Tudormobile.FinancialData.Entities;
+
+/// <summary>
+/// Represents option Greeks (Delta, Gamma, Theta, Vega, Rho) for an option contract.
+/// <para>See: https://financialdata.net/documentation#option_greeks</para>
+/// </summary>
+public record OptionGreeks
+{
+    /// <summary>
+    /// Gets or sets the option contract name.
+    /// </summary>
+    public string? ContractName { get; init; }
+
+    /// <summary>
+    /// Gets or sets the date of the Greeks values.
+    /// </summary>
+    public DateOnly Date { get; init; }
+
+    /// <summary>
+    /// Gets or sets the Delta value.
+    /// </summary>
+    public decimal Delta { get; init; }
+
+    /// <summary>
+    /// Gets or sets the Gamma value.
+    /// </summary>
+    public decimal Gamma { get; init; }
+
+    /// <summary>
+    /// Gets or sets the Theta value.
+    /// </summary>
+    public decimal Theta { get; init; }
+
+    /// <summary>
+    /// Gets or sets the Vega value.
+    /// </summary>
+    public decimal Vega { get; init; }
+
+    /// <summary>
+    /// Gets or sets the Rho value.
+    /// </summary>
+    public decimal Rho { get; init; }
+}

--- a/src/FinancialData/Entities/OptionGreeks.cs
+++ b/src/FinancialData/Entities/OptionGreeks.cs
@@ -7,37 +7,37 @@ namespace Tudormobile.FinancialData.Entities;
 public record OptionGreeks
 {
     /// <summary>
-    /// Gets or sets the option contract name.
+    /// Gets the option contract name.
     /// </summary>
     public string? ContractName { get; init; }
 
     /// <summary>
-    /// Gets or sets the date of the Greeks values.
+    /// Gets the date of the Greeks values.
     /// </summary>
     public DateOnly Date { get; init; }
 
     /// <summary>
-    /// Gets or sets the Delta value.
+    /// Gets the Delta value.
     /// </summary>
     public decimal Delta { get; init; }
 
     /// <summary>
-    /// Gets or sets the Gamma value.
+    /// Gets the Gamma value.
     /// </summary>
     public decimal Gamma { get; init; }
 
     /// <summary>
-    /// Gets or sets the Theta value.
+    /// Gets the Theta value.
     /// </summary>
     public decimal Theta { get; init; }
 
     /// <summary>
-    /// Gets or sets the Vega value.
+    /// Gets the Vega value.
     /// </summary>
     public decimal Vega { get; init; }
 
     /// <summary>
-    /// Gets or sets the Rho value.
+    /// Gets the Rho value.
     /// </summary>
     public decimal Rho { get; init; }
 }

--- a/src/FinancialData/Entities/OptionPrice.cs
+++ b/src/FinancialData/Entities/OptionPrice.cs
@@ -7,37 +7,37 @@ namespace Tudormobile.FinancialData.Entities;
 public record OptionPrice
 {
     /// <summary>
-    /// Gets or sets the option contract name.
+    /// Gets the option contract name.
     /// </summary>
     public string? ContractName { get; init; }
 
     /// <summary>
-    /// Gets or sets the date of the price record.
+    /// Gets the date of the price record.
     /// </summary>
     public DateOnly Date { get; init; }
 
     /// <summary>
-    /// Gets or sets the opening price.
+    /// Gets the opening price.
     /// </summary>
     public decimal Open { get; init; }
 
     /// <summary>
-    /// Gets or sets the highest price.
+    /// Gets the highest price.
     /// </summary>
     public decimal High { get; init; }
 
     /// <summary>
-    /// Gets or sets the lowest price.
+    /// Gets the lowest price.
     /// </summary>
     public decimal Low { get; init; }
 
     /// <summary>
-    /// Gets or sets the closing price.
+    /// Gets the closing price.
     /// </summary>
     public decimal Close { get; init; }
 
     /// <summary>
-    /// Gets or sets the trading volume.
+    /// Gets the trading volume.
     /// </summary>
     public decimal Volume { get; init; }
 }

--- a/src/FinancialData/Entities/OptionPrice.cs
+++ b/src/FinancialData/Entities/OptionPrice.cs
@@ -1,0 +1,43 @@
+namespace Tudormobile.FinancialData.Entities;
+
+/// <summary>
+/// Represents daily historical option price data including open, high, low, close, and volume.
+/// <para>See: https://financialdata.net/documentation#option_prices</para>
+/// </summary>
+public record OptionPrice
+{
+    /// <summary>
+    /// Gets or sets the option contract name.
+    /// </summary>
+    public string? ContractName { get; init; }
+
+    /// <summary>
+    /// Gets or sets the date of the price record.
+    /// </summary>
+    public DateOnly Date { get; init; }
+
+    /// <summary>
+    /// Gets or sets the opening price.
+    /// </summary>
+    public decimal Open { get; init; }
+
+    /// <summary>
+    /// Gets or sets the highest price.
+    /// </summary>
+    public decimal High { get; init; }
+
+    /// <summary>
+    /// Gets or sets the lowest price.
+    /// </summary>
+    public decimal Low { get; init; }
+
+    /// <summary>
+    /// Gets or sets the closing price.
+    /// </summary>
+    public decimal Close { get; init; }
+
+    /// <summary>
+    /// Gets or sets the trading volume.
+    /// </summary>
+    public decimal Volume { get; init; }
+}

--- a/src/FinancialData/Entities/PressRelease.cs
+++ b/src/FinancialData/Entities/PressRelease.cs
@@ -1,0 +1,43 @@
+namespace Tudormobile.FinancialData.Entities;
+
+/// <summary>
+/// Represents a company press release with headline, date, and content.
+/// <para>See: https://financialdata.net/documentation#press_releases</para>
+/// </summary>
+public record PressRelease
+{
+    /// <summary>
+    /// Gets or sets the trading symbol of the company.
+    /// </summary>
+    public string? TradingSymbol { get; init; }
+
+    /// <summary>
+    /// Gets or sets the central index key (CIK) assigned by the SEC.
+    /// </summary>
+    public string? CentralIndexKey { get; init; }
+
+    /// <summary>
+    /// Gets or sets the registrant name of the company.
+    /// </summary>
+    public string? RegistrantName { get; init; }
+
+    /// <summary>
+    /// Gets or sets the date and time of the press release.
+    /// </summary>
+    public DateTime DateTime { get; init; }
+
+    /// <summary>
+    /// Gets or sets the headline of the press release.
+    /// </summary>
+    public string? Headline { get; init; }
+
+    /// <summary>
+    /// Gets or sets the full text content of the press release.
+    /// </summary>
+    public string? Text { get; init; }
+
+    /// <summary>
+    /// Gets or sets the URL to the press release.
+    /// </summary>
+    public string? Url { get; init; }
+}

--- a/src/FinancialData/Entities/PressRelease.cs
+++ b/src/FinancialData/Entities/PressRelease.cs
@@ -7,37 +7,37 @@ namespace Tudormobile.FinancialData.Entities;
 public record PressRelease
 {
     /// <summary>
-    /// Gets or sets the trading symbol of the company.
+    /// Gets the trading symbol of the company.
     /// </summary>
     public string? TradingSymbol { get; init; }
 
     /// <summary>
-    /// Gets or sets the central index key (CIK) assigned by the SEC.
+    /// Gets the central index key (CIK) assigned by the SEC.
     /// </summary>
     public string? CentralIndexKey { get; init; }
 
     /// <summary>
-    /// Gets or sets the registrant name of the company.
+    /// Gets the registrant name of the company.
     /// </summary>
     public string? RegistrantName { get; init; }
 
     /// <summary>
-    /// Gets or sets the date and time of the press release.
+    /// Gets the date and time of the press release.
     /// </summary>
     public DateTime DateTime { get; init; }
 
     /// <summary>
-    /// Gets or sets the headline of the press release.
+    /// Gets the headline of the press release.
     /// </summary>
     public string? Headline { get; init; }
 
     /// <summary>
-    /// Gets or sets the full text content of the press release.
+    /// Gets the full text content of the press release.
     /// </summary>
     public string? Text { get; init; }
 
     /// <summary>
-    /// Gets or sets the URL to the press release.
+    /// Gets the URL to the press release.
     /// </summary>
     public string? Url { get; init; }
 }

--- a/src/FinancialData/Entities/ProposedSale.cs
+++ b/src/FinancialData/Entities/ProposedSale.cs
@@ -1,0 +1,43 @@
+namespace Tudormobile.FinancialData.Entities;
+
+/// <summary>
+/// Represents a proposed insider sale reported to the SEC via Form 144.
+/// <para>See: https://financialdata.net/documentation#proposed_sales</para>
+/// </summary>
+public record ProposedSale
+{
+    /// <summary>
+    /// Gets or sets the trading symbol of the company.
+    /// </summary>
+    public string? TradingSymbol { get; init; }
+
+    /// <summary>
+    /// Gets or sets the central index key (CIK) assigned by the SEC.
+    /// </summary>
+    public string? CentralIndexKey { get; init; }
+
+    /// <summary>
+    /// Gets or sets the registrant name of the company.
+    /// </summary>
+    public string? RegistrantName { get; init; }
+
+    /// <summary>
+    /// Gets or sets the name of the insider.
+    /// </summary>
+    public string? InsiderName { get; init; }
+
+    /// <summary>
+    /// Gets or sets the filing date with the SEC.
+    /// </summary>
+    public DateOnly FilingDate { get; init; }
+
+    /// <summary>
+    /// Gets or sets the number of shares proposed for sale.
+    /// </summary>
+    public decimal Shares { get; init; }
+
+    /// <summary>
+    /// Gets or sets the URL to the SEC filing.
+    /// </summary>
+    public string? SecFilingUrl { get; init; }
+}

--- a/src/FinancialData/Entities/ProposedSale.cs
+++ b/src/FinancialData/Entities/ProposedSale.cs
@@ -7,37 +7,37 @@ namespace Tudormobile.FinancialData.Entities;
 public record ProposedSale
 {
     /// <summary>
-    /// Gets or sets the trading symbol of the company.
+    /// Gets the trading symbol of the company.
     /// </summary>
     public string? TradingSymbol { get; init; }
 
     /// <summary>
-    /// Gets or sets the central index key (CIK) assigned by the SEC.
+    /// Gets the central index key (CIK) assigned by the SEC.
     /// </summary>
     public string? CentralIndexKey { get; init; }
 
     /// <summary>
-    /// Gets or sets the registrant name of the company.
+    /// Gets the registrant name of the company.
     /// </summary>
     public string? RegistrantName { get; init; }
 
     /// <summary>
-    /// Gets or sets the name of the insider.
+    /// Gets the name of the insider.
     /// </summary>
     public string? InsiderName { get; init; }
 
     /// <summary>
-    /// Gets or sets the filing date with the SEC.
+    /// Gets the filing date with the SEC.
     /// </summary>
     public DateOnly FilingDate { get; init; }
 
     /// <summary>
-    /// Gets or sets the number of shares proposed for sale.
+    /// Gets the number of shares proposed for sale.
     /// </summary>
     public decimal Shares { get; init; }
 
     /// <summary>
-    /// Gets or sets the URL to the SEC filing.
+    /// Gets the URL to the SEC filing.
     /// </summary>
     public string? SecFilingUrl { get; init; }
 }

--- a/src/FinancialData/Entities/SecPressRelease.cs
+++ b/src/FinancialData/Entities/SecPressRelease.cs
@@ -7,22 +7,22 @@ namespace Tudormobile.FinancialData.Entities;
 public record SecPressRelease
 {
     /// <summary>
-    /// Gets or sets the date and time of the SEC press release.
+    /// Gets the date and time of the SEC press release.
     /// </summary>
     public DateTime DateTime { get; init; }
 
     /// <summary>
-    /// Gets or sets the headline of the press release.
+    /// Gets the headline of the press release.
     /// </summary>
     public string? Headline { get; init; }
 
     /// <summary>
-    /// Gets or sets the full text content of the press release.
+    /// Gets the full text content of the press release.
     /// </summary>
     public string? Text { get; init; }
 
     /// <summary>
-    /// Gets or sets the URL to the press release.
+    /// Gets the URL to the press release.
     /// </summary>
     public string? Url { get; init; }
 }

--- a/src/FinancialData/Entities/SecPressRelease.cs
+++ b/src/FinancialData/Entities/SecPressRelease.cs
@@ -1,0 +1,28 @@
+namespace Tudormobile.FinancialData.Entities;
+
+/// <summary>
+/// Represents an SEC press release with headline, date, and content.
+/// <para>See: https://financialdata.net/documentation#sec_press_releases</para>
+/// </summary>
+public record SecPressRelease
+{
+    /// <summary>
+    /// Gets or sets the date and time of the SEC press release.
+    /// </summary>
+    public DateTime DateTime { get; init; }
+
+    /// <summary>
+    /// Gets or sets the headline of the press release.
+    /// </summary>
+    public string? Headline { get; init; }
+
+    /// <summary>
+    /// Gets or sets the full text content of the press release.
+    /// </summary>
+    public string? Text { get; init; }
+
+    /// <summary>
+    /// Gets or sets the URL to the press release.
+    /// </summary>
+    public string? Url { get; init; }
+}

--- a/src/FinancialData/Entities/SecuritiesInformation.cs
+++ b/src/FinancialData/Entities/SecuritiesInformation.cs
@@ -1,0 +1,38 @@
+namespace Tudormobile.FinancialData.Entities;
+
+/// <summary>
+/// Represents basic information about a security including its trading symbol, issuer, CUSIP, ISIN, FIGI, and security type.
+/// <para>See: https://financialdata.net/documentation#securities_information</para>
+/// </summary>
+public record SecuritiesInformation
+{
+    /// <summary>
+    /// Gets or sets the trading symbol of the security.
+    /// </summary>
+    public string? TradingSymbol { get; init; }
+
+    /// <summary>
+    /// Gets or sets the name of the issuer.
+    /// </summary>
+    public string? IssuerName { get; init; }
+
+    /// <summary>
+    /// Gets or sets the CUSIP number.
+    /// </summary>
+    public string? CusipNumber { get; init; }
+
+    /// <summary>
+    /// Gets or sets the ISIN number.
+    /// </summary>
+    public string? IsinNumber { get; init; }
+
+    /// <summary>
+    /// Gets or sets the FIGI (Financial Instrument Global Identifier).
+    /// </summary>
+    public string? FigiIdentifier { get; init; }
+
+    /// <summary>
+    /// Gets or sets the type of security.
+    /// </summary>
+    public string? SecurityType { get; init; }
+}

--- a/src/FinancialData/Entities/SecuritiesInformation.cs
+++ b/src/FinancialData/Entities/SecuritiesInformation.cs
@@ -7,32 +7,32 @@ namespace Tudormobile.FinancialData.Entities;
 public record SecuritiesInformation
 {
     /// <summary>
-    /// Gets or sets the trading symbol of the security.
+    /// Gets the trading symbol of the security.
     /// </summary>
     public string? TradingSymbol { get; init; }
 
     /// <summary>
-    /// Gets or sets the name of the issuer.
+    /// Gets the name of the issuer.
     /// </summary>
     public string? IssuerName { get; init; }
 
     /// <summary>
-    /// Gets or sets the CUSIP number.
+    /// Gets the CUSIP number.
     /// </summary>
     public string? CusipNumber { get; init; }
 
     /// <summary>
-    /// Gets or sets the ISIN number.
+    /// Gets the ISIN number.
     /// </summary>
     public string? IsinNumber { get; init; }
 
     /// <summary>
-    /// Gets or sets the FIGI (Financial Instrument Global Identifier).
+    /// Gets the FIGI (Financial Instrument Global Identifier).
     /// </summary>
     public string? FigiIdentifier { get; init; }
 
     /// <summary>
-    /// Gets or sets the type of security.
+    /// Gets the type of security.
     /// </summary>
     public string? SecurityType { get; init; }
 }

--- a/src/FinancialData/Entities/SenateTrading.cs
+++ b/src/FinancialData/Entities/SenateTrading.cs
@@ -7,42 +7,42 @@ namespace Tudormobile.FinancialData.Entities;
 public record SenateTrading
 {
     /// <summary>
-    /// Gets or sets the trading symbol of the company.
+    /// Gets the trading symbol of the company.
     /// </summary>
     public string? TradingSymbol { get; init; }
 
     /// <summary>
-    /// Gets or sets the name of the Senator.
+    /// Gets the name of the Senator.
     /// </summary>
     public string? SenatorName { get; init; }
 
     /// <summary>
-    /// Gets or sets the date of the transaction.
+    /// Gets the date of the transaction.
     /// </summary>
     public DateOnly TransactionDate { get; init; }
 
     /// <summary>
-    /// Gets or sets the disclosure date.
+    /// Gets the disclosure date.
     /// </summary>
     public DateOnly DisclosureDate { get; init; }
 
     /// <summary>
-    /// Gets or sets the transaction type (e.g., Purchase, Sale).
+    /// Gets the transaction type (e.g., Purchase, Sale).
     /// </summary>
     public string? TransactionType { get; init; }
 
     /// <summary>
-    /// Gets or sets the asset type (e.g., Stock, Stock Option).
+    /// Gets the asset type (e.g., Stock, Stock Option).
     /// </summary>
     public string? AssetType { get; init; }
 
     /// <summary>
-    /// Gets or sets the amount range of the transaction.
+    /// Gets the amount range of the transaction.
     /// </summary>
     public string? AmountRange { get; init; }
 
     /// <summary>
-    /// Gets or sets additional comments.
+    /// Gets additional comments.
     /// </summary>
     public string? Comment { get; init; }
 }

--- a/src/FinancialData/Entities/SenateTrading.cs
+++ b/src/FinancialData/Entities/SenateTrading.cs
@@ -1,0 +1,48 @@
+namespace Tudormobile.FinancialData.Entities;
+
+/// <summary>
+/// Represents a stock transaction by a U.S. Senator.
+/// <para>See: https://financialdata.net/documentation#senate_trading</para>
+/// </summary>
+public record SenateTrading
+{
+    /// <summary>
+    /// Gets or sets the trading symbol of the company.
+    /// </summary>
+    public string? TradingSymbol { get; init; }
+
+    /// <summary>
+    /// Gets or sets the name of the Senator.
+    /// </summary>
+    public string? SenatorName { get; init; }
+
+    /// <summary>
+    /// Gets or sets the date of the transaction.
+    /// </summary>
+    public DateOnly TransactionDate { get; init; }
+
+    /// <summary>
+    /// Gets or sets the disclosure date.
+    /// </summary>
+    public DateOnly DisclosureDate { get; init; }
+
+    /// <summary>
+    /// Gets or sets the transaction type (e.g., Purchase, Sale).
+    /// </summary>
+    public string? TransactionType { get; init; }
+
+    /// <summary>
+    /// Gets or sets the asset type (e.g., Stock, Stock Option).
+    /// </summary>
+    public string? AssetType { get; init; }
+
+    /// <summary>
+    /// Gets or sets the amount range of the transaction.
+    /// </summary>
+    public string? AmountRange { get; init; }
+
+    /// <summary>
+    /// Gets or sets additional comments.
+    /// </summary>
+    public string? Comment { get; init; }
+}

--- a/src/FinancialData/Entities/ShortInterest.cs
+++ b/src/FinancialData/Entities/ShortInterest.cs
@@ -7,57 +7,57 @@ namespace Tudormobile.FinancialData.Entities;
 public record ShortInterest
 {
     /// <summary>
-    /// Gets or sets the trading symbol of the security.
+    /// Gets the trading symbol of the security.
     /// </summary>
     public string? TradingSymbol { get; init; }
 
     /// <summary>
-    /// Gets or sets the title of the security.
+    /// Gets the title of the security.
     /// </summary>
     public string? TitleOfSecurity { get; init; }
 
     /// <summary>
-    /// Gets or sets the market code.
+    /// Gets the market code.
     /// </summary>
     public string? MarketCode { get; init; }
 
     /// <summary>
-    /// Gets or sets the settlement date.
+    /// Gets the settlement date.
     /// </summary>
     public DateOnly SettlementDate { get; init; }
 
     /// <summary>
-    /// Gets or sets the number of shorted securities.
+    /// Gets the number of shorted securities.
     /// </summary>
     public decimal ShortedSecurities { get; init; }
 
     /// <summary>
-    /// Gets or sets the previous number of shorted securities.
+    /// Gets the previous number of shorted securities.
     /// </summary>
     public decimal PreviousShortedSecurities { get; init; }
 
     /// <summary>
-    /// Gets or sets the change in shorted securities.
+    /// Gets the change in shorted securities.
     /// </summary>
     public decimal ChangeInShortedSecurities { get; init; }
 
     /// <summary>
-    /// Gets or sets the percentage change in shorted securities.
+    /// Gets the percentage change in shorted securities.
     /// </summary>
     public decimal PercentageChangeInShortedSecurities { get; init; }
 
     /// <summary>
-    /// Gets or sets the average daily volume.
+    /// Gets the average daily volume.
     /// </summary>
     public decimal AverageDailyVolume { get; init; }
 
     /// <summary>
-    /// Gets or sets the days to cover (short interest ratio).
+    /// Gets the days to cover (short interest ratio).
     /// </summary>
     public decimal DaysToCover { get; init; }
 
     /// <summary>
-    /// Gets or sets whether a stock split occurred.
+    /// Gets whether a stock split occurred.
     /// </summary>
     public bool IsStockSplit { get; init; }
 }

--- a/src/FinancialData/Entities/ShortInterest.cs
+++ b/src/FinancialData/Entities/ShortInterest.cs
@@ -1,0 +1,63 @@
+namespace Tudormobile.FinancialData.Entities;
+
+/// <summary>
+/// Represents short interest data including number of shares sold short, days to cover, and percentage changes.
+/// <para>See: https://financialdata.net/documentation#short_interest</para>
+/// </summary>
+public record ShortInterest
+{
+    /// <summary>
+    /// Gets or sets the trading symbol of the security.
+    /// </summary>
+    public string? TradingSymbol { get; init; }
+
+    /// <summary>
+    /// Gets or sets the title of the security.
+    /// </summary>
+    public string? TitleOfSecurity { get; init; }
+
+    /// <summary>
+    /// Gets or sets the market code.
+    /// </summary>
+    public string? MarketCode { get; init; }
+
+    /// <summary>
+    /// Gets or sets the settlement date.
+    /// </summary>
+    public DateOnly SettlementDate { get; init; }
+
+    /// <summary>
+    /// Gets or sets the number of shorted securities.
+    /// </summary>
+    public decimal ShortedSecurities { get; init; }
+
+    /// <summary>
+    /// Gets or sets the previous number of shorted securities.
+    /// </summary>
+    public decimal PreviousShortedSecurities { get; init; }
+
+    /// <summary>
+    /// Gets or sets the change in shorted securities.
+    /// </summary>
+    public decimal ChangeInShortedSecurities { get; init; }
+
+    /// <summary>
+    /// Gets or sets the percentage change in shorted securities.
+    /// </summary>
+    public decimal PercentageChangeInShortedSecurities { get; init; }
+
+    /// <summary>
+    /// Gets or sets the average daily volume.
+    /// </summary>
+    public decimal AverageDailyVolume { get; init; }
+
+    /// <summary>
+    /// Gets or sets the days to cover (short interest ratio).
+    /// </summary>
+    public decimal DaysToCover { get; init; }
+
+    /// <summary>
+    /// Gets or sets whether a stock split occurred.
+    /// </summary>
+    public bool IsStockSplit { get; init; }
+}

--- a/src/FinancialData/Entities/SplitsCalendar.cs
+++ b/src/FinancialData/Entities/SplitsCalendar.cs
@@ -1,0 +1,28 @@
+namespace Tudormobile.FinancialData.Entities;
+
+/// <summary>
+/// Represents an upcoming stock split on the splits calendar.
+/// <para>See: https://financialdata.net/documentation#splits_calendar</para>
+/// </summary>
+public record SplitsCalendar
+{
+    /// <summary>
+    /// Gets or sets the trading symbol of the company.
+    /// </summary>
+    public string? TradingSymbol { get; init; }
+
+    /// <summary>
+    /// Gets or sets the registrant name of the company.
+    /// </summary>
+    public string? RegistrantName { get; init; }
+
+    /// <summary>
+    /// Gets or sets the execution date of the stock split.
+    /// </summary>
+    public DateOnly ExecutionDate { get; init; }
+
+    /// <summary>
+    /// Gets or sets the split multiplier (e.g., 1.5 for 3-for-2 split).
+    /// </summary>
+    public decimal Multiplier { get; init; }
+}

--- a/src/FinancialData/Entities/SplitsCalendar.cs
+++ b/src/FinancialData/Entities/SplitsCalendar.cs
@@ -7,22 +7,22 @@ namespace Tudormobile.FinancialData.Entities;
 public record SplitsCalendar
 {
     /// <summary>
-    /// Gets or sets the trading symbol of the company.
+    /// Gets the trading symbol of the company.
     /// </summary>
     public string? TradingSymbol { get; init; }
 
     /// <summary>
-    /// Gets or sets the registrant name of the company.
+    /// Gets the registrant name of the company.
     /// </summary>
     public string? RegistrantName { get; init; }
 
     /// <summary>
-    /// Gets or sets the execution date of the stock split.
+    /// Gets the execution date of the stock split.
     /// </summary>
     public DateOnly ExecutionDate { get; init; }
 
     /// <summary>
-    /// Gets or sets the split multiplier (e.g., 1.5 for 3-for-2 split).
+    /// Gets the split multiplier (e.g., 1.5 for 3-for-2 split).
     /// </summary>
     public decimal Multiplier { get; init; }
 }

--- a/src/FinancialData/Entities/StockPrice.cs
+++ b/src/FinancialData/Entities/StockPrice.cs
@@ -1,4 +1,4 @@
-﻿namespace Tudormobile.FinancialData.Entities;
+namespace Tudormobile.FinancialData.Entities;
 
 /// <summary>
 /// Represents daily stock price information for a specific trading symbol, including open, high, low, close prices, and
@@ -13,12 +13,12 @@ public record StockPrice
     private DateTimeOffset? _time;
 
     /// <summary>
-    /// Gets or sets the trading symbol associated with the financial instrument.
+    /// Gets the trading symbol associated with the financial instrument.
     /// </summary>
     public string? TradingSymbol { get; init; }
 
     /// <summary>
-    /// Gets or sets the date associated with the record.
+    /// Gets the date associated with the record.
     /// </summary>
     public DateOnly Date
     {
@@ -39,27 +39,27 @@ public record StockPrice
     }
 
     /// <summary>
-    /// Gets or sets the opening price of the asset for the trading period.
+    /// Gets the opening price of the asset for the trading period.
     /// </summary>
     public decimal Open { get; init; }
 
     /// <summary>
-    /// Gets or sets the highest price recorded during the relevant time period.
+    /// Gets the highest price recorded during the relevant time period.
     /// </summary>
     public decimal High { get; init; }
 
     /// <summary>
-    /// Gets or sets the lowest price recorded during the relevant time period.
+    /// Gets the lowest price recorded during the relevant time period.
     /// </summary>
     public decimal Low { get; init; }
 
     /// <summary>
-    /// Gets or sets the closing price of the asset for the trading period.
+    /// Gets the closing price of the asset for the trading period.
     /// </summary>
     public decimal Close { get; init; }
 
     /// <summary>
-    /// Gets or sets the total traded volume for the security.
+    /// Gets the total traded volume for the security.
     /// </summary>
     public decimal Volume { get; init; }
 

--- a/src/FinancialData/Entities/StockSplit.cs
+++ b/src/FinancialData/Entities/StockSplit.cs
@@ -1,0 +1,33 @@
+namespace Tudormobile.FinancialData.Entities;
+
+/// <summary>
+/// Represents stock split data including execution date and split multiplier.
+/// <para>See: https://financialdata.net/documentation#stock_splits</para>
+/// </summary>
+public record StockSplit
+{
+    /// <summary>
+    /// Gets or sets the trading symbol of the company.
+    /// </summary>
+    public string? TradingSymbol { get; init; }
+
+    /// <summary>
+    /// Gets or sets the central index key (CIK) assigned by the SEC.
+    /// </summary>
+    public string? CentralIndexKey { get; init; }
+
+    /// <summary>
+    /// Gets or sets the registrant name of the company.
+    /// </summary>
+    public string? RegistrantName { get; init; }
+
+    /// <summary>
+    /// Gets or sets the execution date of the stock split.
+    /// </summary>
+    public DateOnly ExecutionDate { get; init; }
+
+    /// <summary>
+    /// Gets or sets the split multiplier (e.g., 2.0 for 2-for-1 split).
+    /// </summary>
+    public decimal Multiplier { get; init; }
+}

--- a/src/FinancialData/Entities/StockSplit.cs
+++ b/src/FinancialData/Entities/StockSplit.cs
@@ -27,7 +27,11 @@ public record StockSplit
     public DateOnly ExecutionDate { get; init; }
 
     /// <summary>
-    /// Gets or sets the split multiplier (e.g., 2.0 for 2-for-1 split).
+    /// Gets the ratio that represents how a stock has been split, typically expressed as a string (for example, "2:1").
     /// </summary>
-    public decimal Multiplier { get; init; }
+    /// <remarks>The split ratio indicates the proportion by which shares are divided during a stock split.
+    /// The value should follow the expected format (such as "2:1" or "3:2") to ensure correct interpretation.
+    /// </remarks>
+    public string? SplitRatio { get; init; }
+
 }

--- a/src/FinancialData/Entities/StockSplit.cs
+++ b/src/FinancialData/Entities/StockSplit.cs
@@ -7,22 +7,22 @@ namespace Tudormobile.FinancialData.Entities;
 public record StockSplit
 {
     /// <summary>
-    /// Gets or sets the trading symbol of the company.
+    /// Gets the trading symbol of the company.
     /// </summary>
     public string? TradingSymbol { get; init; }
 
     /// <summary>
-    /// Gets or sets the central index key (CIK) assigned by the SEC.
+    /// Gets the central index key (CIK) assigned by the SEC.
     /// </summary>
     public string? CentralIndexKey { get; init; }
 
     /// <summary>
-    /// Gets or sets the registrant name of the company.
+    /// Gets the registrant name of the company.
     /// </summary>
     public string? RegistrantName { get; init; }
 
     /// <summary>
-    /// Gets or sets the execution date of the stock split.
+    /// Gets the execution date of the stock split.
     /// </summary>
     public DateOnly ExecutionDate { get; init; }
 

--- a/src/FinancialData/FinancialDataResponse.cs
+++ b/src/FinancialData/FinancialDataResponse.cs
@@ -53,6 +53,6 @@ public class FinancialDataResponse<T>
     /// <returns>A task containing a <see cref="FinancialDataResponse{T}"/> object with an error message stating that the premium
     /// subscription API is not implemented.</returns>
     public static Task<FinancialDataResponse<T>> StandardSubscriptionNotImplemented()
-        => Task.FromResult(new FinancialDataResponse<T>(error: "Premium subscription api not implemented."));
+        => Task.FromResult(new FinancialDataResponse<T>(error: "Standard subscription api not implemented."));
 
 }

--- a/src/FinancialData/FinancialDataResponse.cs
+++ b/src/FinancialData/FinancialDataResponse.cs
@@ -48,9 +48,9 @@ public class FinancialDataResponse<T>
 
     /// <summary>
     /// Returns a task that represents the asynchronous operation of retrieving financial data, indicating that the
-    /// premium subscription API is not implemented.    
+    /// standard subscription API is not implemented.    
     /// </summary>
-    /// <returns>A task containing a <see cref="FinancialDataResponse{T}"/> object with an error message stating that the premium
+    /// <returns>A task containing a <see cref="FinancialDataResponse{T}"/> object with an error message stating that the standard
     /// subscription API is not implemented.</returns>
     public static Task<FinancialDataResponse<T>> StandardSubscriptionNotImplemented()
         => Task.FromResult(new FinancialDataResponse<T>(error: "Standard subscription api not implemented."));


### PR DESCRIPTION
This pull request adds comprehensive unit tests for JSON deserialization of various financial entity classes, ensuring that the deserialization logic correctly maps JSON fields to object properties and handles null values as expected. Additionally, it updates an existing test to reflect the behavior of the `DecimalNullToZeroConverter`.

Unit tests for entity deserialization:

* Added new tests for deserialization of the following entities, verifying that properties are correctly parsed from JSON and that null numeric fields are converted to zero:
  - `CompanyInformation` (`CompanyInformationTests.cs`)
  - `CryptoInformation`, `CryptoMinutePrice`, `CryptoPrice`, `CryptoQuote`, and `CryptoSymbol` (`CryptoInformationTests.cs`, `CryptoMinutePriceTests.cs`, `CryptoPriceTests.cs`, `CryptoQuoteTests.cs`, `CryptoSymbolTests.cs`) [[1]](diffhunk://#diff-c9bc7602d364d4e8de3d25d1efe5861605d868e3c485cb525d7d1e3c0c6ccc1aR1-R30) [[2]](diffhunk://#diff-194cc6bb645f8e5a64e76a09ac97807be681dce9d4f007843b0307b2e5d858d8R1-R31) [[3]](diffhunk://#diff-1ba7d014d3a5e304e2e63103d5651281487a93885673f7e79ae1110d418a72faR1-R32) [[4]](diffhunk://#diff-8b5e1fb6d6bdcdb4d37f261d18d1025bb13618c15b966fa2d2b6b6b293ff0c99R1-R50) [[5]](diffhunk://#diff-35f91b33d1dfb3c1a348bf98df3b82761265911046d3c1374d147f89fb7b819bR1-R24)
  - `Dividend` and `DividendsCalendar` (`DividendTests.cs`, `DividendsCalendarTests.cs`) [[1]](diffhunk://#diff-2ef208448fab846876247a1e7c5b1355283cd7f85e14c7efb03525a4ab4c39deR1-R31) [[2]](diffhunk://#diff-3e9bed3dc84d408bdc450ee81e48f91d506a57521ea4bd87a227328c27e501e6R1-R25)
  - `EarningsCalendar` and `EarningsRelease` (`EarningsCalendarTests.cs`, `EarningsReleaseTests.cs`) [[1]](diffhunk://#diff-bd0522c0cc3027c043e5378c8c3e5a152a43d5d290801aeeedcc2c39b20b2b98R1-R25) [[2]](diffhunk://#diff-e8bf2004573cf4abeaef901015a0a2592c78112e7c14967f46052c00f05b1489R1-R34)
  - `EconomicCalendar`, `EmployeeCount`, `EsgRating`, and `EsgScore` (`EconomicCalendarTests.cs`, `EmployeeCountTests.cs`, `EsgRatingTests.cs`, `EsgScoreTests.cs`) [[1]](diffhunk://#diff-5963244d2cfbb22f52a7dc1db140833e4c1353e92ffa5c6c1c4e793f1247c7a1R1-R29) [[2]](diffhunk://#diff-14d3309719fe08c5ce9b250f04a3f6117912713835ffe570fab4eb680f8e8a36R1-R28) [[3]](diffhunk://#diff-7611c5e7b3b6ba2ab3afbe21615b1503dc248e3f18fc3f7b873f77d59f8cfab7R1-R32) [[4]](diffhunk://#diff-dc78c9e5a33e1ceb6767a867a797c15ca9fe612c81cef03a4b385b5fb4aa0753R1-R35)
  - `EtfHoldings` and `EtfPrices` (`EtfHoldingsTests.cs`, `EtfPricesTests.cs`) [[1]](diffhunk://#diff-64fd3163fec06e8677f907b91b442010a1b631baf78a4b30998b70f9cfb5fa2aR1-R52) [[2]](diffhunk://#diff-478f468f7f71c955ede854daf392907032b359c0496bd9c44f6248419b478faeR1-R32)

Behavioral test updates:

* Updated the `BalanceSheet_Deserialize_FromJson_Works` test to assert that null decimal fields are converted to zero, matching the behavior of `DecimalNullToZeroConverter` (`BalanceSheetTests.cs`)